### PR TITLE
Introduce single instance enforcement on the Chrome extension popout

### DIFF
--- a/packages/platform-extension/src/background/popout.ts
+++ b/packages/platform-extension/src/background/popout.ts
@@ -8,52 +8,67 @@ import { armViewGrace } from "./view-lock";
 export const POPOUT_HANDOFF_KEY = "popout.handoff";
 
 async function popoutOpen(
-	message: any,
-	sender: chrome.runtime.MessageSender,
+  message: any,
+  sender: chrome.runtime.MessageSender,
 ): Promise<MessageEnvelope> {
-	// The popup closes as the detached window takes focus; hold "Immediate" auto-lock across
-	// that gap so popping out doesn't lock the vault out from under the new window.
-	armViewGrace();
-	// Stash the handoff before creating the window so the new window's boot read sees it.
-	const handoff = (message.payload as { handoff?: unknown } | undefined)?.handoff;
-	if (handoff) {
-		await api.storage.session.set({ [POPOUT_HANDOFF_KEY]: handoff });
-	} else {
-		await api.storage.session.remove([POPOUT_HANDOFF_KEY]);
-	}
-	const WIDTH = 500;
-	const HEIGHT = 600;
-	const CHROME_INSET = 80;
-	// Prefer the sender's window so the pop-out lands next to the active tab.
-	let anchor: chrome.windows.Window | undefined;
-	if (sender.tab?.windowId !== undefined) {
-		anchor = await api.windows.get(sender.tab.windowId).catch(() => undefined);
-	}
-	if (!anchor) {
-		anchor = await api.windows.getCurrent().catch(() => undefined);
-	}
-	const top = (anchor?.top ?? 0) + CHROME_INSET;
-	const left = (anchor?.left ?? 0) + (anchor?.width ?? WIDTH) - WIDTH;
-	const created = await api.windows.create({
-		url: api.runtime.getURL("popup.html?detached=1"),
-		type: "popup",
-		focused: true,
-		width: WIDTH,
-		height: HEIGHT,
-		top,
-		left,
-	});
-	if (created?.id !== undefined) {
-		await api.windows.update(created.id, {
-			state: "normal",
-			width: WIDTH,
-			height: HEIGHT,
-			top,
-			left,
-		});
-	}
-	return { ok: true };
+  const targetUrl = api.runtime.getURL("popup.html?detached=1");
+  const WIDTH = 500;
+  const HEIGHT = 600;
+  const CHROME_INSET = 80;
+
+  // CHECK FOR EXISTING INSTANCE: Query tabs for our unique detached extension URL
+  const [existingTab] = await api.tabs.query({ url: targetUrl }).catch(() => []);
+
+  if (existingTab?.windowId !== undefined) {
+    // SINGLE WINDOW ENFORCEMENT: Bring the existing window to the front
+    await api.windows.update(existingTab.windowId, { focused: true }).catch(() => undefined);
+    armViewGrace();
+    return { ok: true };
+  }
+
+  // --- Fallback to original window creation logic if no instance exists ---
+  armViewGrace();
+  const handoff = (message.payload as { handoff?: unknown } | undefined)?.handoff;
+  if (handoff) {
+    await api.storage.session.set({ [POPOUT_HANDOFF_KEY]: handoff });
+  } else {
+    await api.storage.session.remove([POPOUT_HANDOFF_KEY]);
+  }
+
+  let anchor: chrome.windows.Window | undefined;
+  if (sender.tab?.windowId !== undefined) {
+    anchor = await api.windows.get(sender.tab.windowId).catch(() => undefined);
+  }
+  if (!anchor) {
+    anchor = await api.windows.getCurrent().catch(() => undefined);
+  }
+
+  const top = (anchor?.top ?? 0) + CHROME_INSET;
+  const left = (anchor?.left ?? 0) + (anchor?.width ?? WIDTH) - WIDTH;
+
+  // Create the single instance window
+  const created = await api.windows.create({
+    url: targetUrl,
+    type: "popup",
+    focused: true,
+    width: WIDTH,
+    height: HEIGHT,
+    top,
+    left,
+  });
+
+  if (created?.id !== undefined) {
+    await api.windows.update(created.id, {
+      state: "normal",
+      width: WIDTH,
+      height: HEIGHT,
+      top,
+      left,
+    });
+  }
+  return { ok: true };
 }
+
 
 async function popoutConsumeHandoff(): Promise<MessageEnvelope> {
 	// Read-and-delete one-shot: reloading the window must not re-seed a stale draft.


### PR DESCRIPTION
Refactor popoutOpen to enforce single instance of the popup window. Added logic to check for existing instances before creating a new window.

Needs a corresponding manifest change to allow 'tabs' permission. I made this change in a separate fork (GitHub rookie) so am going to abandon that change.