### PR TITLE
feat(import): import passkeys from Bitwarden JSON exports

### DIFF
--- a/packages/core-rust/src/lib.rs
+++ b/packages/core-rust/src/lib.rs
@@ -580,6 +580,13 @@ mod wasm_exports {
         serde_wasm_bindgen::to_value(&reg).map_err(|e| err(format!("serialize: {e}")))
     }
 
+    /// Convert a base64 P-256 PKCS#8 key into Bramble's scalar and ES256 COSE key.
+    #[wasm_bindgen]
+    pub fn passkey_import_pkcs8(pkcs8_b64: String) -> Result<JsValue, CryptoError> {
+        let imported = crate::passkey::passkey_import_pkcs8_core(&pkcs8_b64)?;
+        serde_wasm_bindgen::to_value(&imported).map_err(|e| err(format!("serialize: {e}")))
+    }
+
     /// Assert a stored passkey: sign authenticatorData || clientDataHash with its key.
     #[wasm_bindgen]
     pub fn passkey_get_assertion(
@@ -644,6 +651,14 @@ mod ffi_exports {
         user_verified: bool,
     ) -> Result<crate::passkey::PasskeyRegistration, CryptoError> {
         crate::passkey::passkey_make_credential_core(&rp_id, user_verified)
+    }
+
+    /// Convert a standard-base64 P-256 PKCS#8 private key into stored key material.
+    #[uniffi::export]
+    pub fn passkey_import_pkcs8(
+        pkcs8_b64: String,
+    ) -> Result<crate::passkey::PasskeyImportResult, CryptoError> {
+        crate::passkey::passkey_import_pkcs8_core(&pkcs8_b64)
     }
 
     /// Assert a stored passkey: sign authenticatorData || clientDataHash with its key.

--- a/packages/core-rust/src/passkey.rs
+++ b/packages/core-rust/src/passkey.rs
@@ -13,7 +13,7 @@ use ciborium::Value;
 use coset::{iana, CborSerializable, CoseKeyBuilder};
 use p256::ecdsa::{signature::Signer, Signature, SigningKey};
 use p256::elliptic_curve::sec1::ToEncodedPoint;
-use p256::pkcs8::EncodePublicKey;
+use p256::pkcs8::{DecodePrivateKey, EncodePublicKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
@@ -64,6 +64,17 @@ pub struct PasskeyRegistration {
     pub public_key: String,
 }
 
+/// Bramble key material converted from a P-256 PKCS#8 key, in standard base64.
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(feature = "ffi", derive(uniffi::Record))]
+pub struct PasskeyImportResult {
+    /// base64 raw P-256 private scalar (32 bytes).
+    pub private_key: String,
+    /// base64 canonical ES256 COSE_Key derived from the private key.
+    pub public_key_cose: String,
+}
+
 /// Result of asserting a passkey. The caller supplies credentialId + userHandle to
 /// the OS; these two fields are the parts that require the private key.
 #[derive(Serialize, Deserialize)]
@@ -103,13 +114,8 @@ fn generate_p256() -> Result<p256::SecretKey, CryptoError> {
     Err(err("p256 keygen: no valid scalar"))
 }
 
-/// Mint a new passkey for `rp_id`. ES256 (COSE -7) only for now.
-pub fn passkey_make_credential_core(
-    rp_id: &str,
-    user_verified: bool,
-) -> Result<PasskeyRegistration, CryptoError> {
-    let secret = generate_p256()?;
-    let public = secret.public_key();
+/// Keep minted and imported passkeys on one canonical ES256 COSE representation.
+fn encode_public_key_cose(public: &p256::PublicKey) -> Result<Vec<u8>, CryptoError> {
     let point = public.to_encoded_point(false);
     let x = point
         .x()
@@ -122,12 +128,35 @@ pub fn passkey_make_credential_core(
         .as_slice()
         .to_vec();
 
-    let cose = CoseKeyBuilder::new_ec2_pub_key(iana::EllipticCurve::P_256, x, y)
+    CoseKeyBuilder::new_ec2_pub_key(iana::EllipticCurve::P_256, x, y)
         .algorithm(iana::Algorithm::ES256)
-        .build();
-    let cose_bytes = cose
+        .build()
         .to_vec()
-        .map_err(|e| err(format!("cose encode: {e}")))?;
+        .map_err(|e| err(format!("cose encode: {e}")))
+}
+
+/// Convert a base64 P-256 PKCS#8 key into Bramble's scalar and ES256 COSE key.
+pub fn passkey_import_pkcs8_core(pkcs8_b64: &str) -> Result<PasskeyImportResult, CryptoError> {
+    let pkcs8_der = Zeroizing::new(b64_decode(pkcs8_b64)?);
+    let secret = p256::SecretKey::from_pkcs8_der(pkcs8_der.as_slice())
+        .map_err(|_| err("invalid P-256 PKCS#8 private key"))?;
+    let public_key_cose = encode_public_key_cose(&secret.public_key())?;
+    let private_key = Zeroizing::new(secret.to_bytes());
+
+    Ok(PasskeyImportResult {
+        private_key: B64.encode(private_key.as_slice()),
+        public_key_cose: B64.encode(public_key_cose),
+    })
+}
+
+/// Mint a new passkey for `rp_id`. ES256 (COSE -7) only for now.
+pub fn passkey_make_credential_core(
+    rp_id: &str,
+    user_verified: bool,
+) -> Result<PasskeyRegistration, CryptoError> {
+    let secret = generate_p256()?;
+    let public = secret.public_key();
+    let cose_bytes = encode_public_key_cose(&public)?;
 
     let mut credential_id = [0u8; CREDENTIAL_ID_LEN];
     random_bytes(&mut credential_id)?;
@@ -199,12 +228,82 @@ pub fn passkey_get_assertion_core(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use coset::{Algorithm, CoseKey, KeyType, Label};
     use p256::ecdsa::{signature::Verifier, VerifyingKey};
+    use p256::pkcs8::EncodePrivateKey;
 
     fn verifying_key(private_key_b64: &str) -> VerifyingKey {
         let bytes = B64.decode(private_key_b64).unwrap();
         let secret = p256::SecretKey::from_slice(&bytes).unwrap();
         VerifyingKey::from(SigningKey::from(&secret))
+    }
+
+    #[test]
+    fn import_pkcs8_derives_stored_key_material_that_can_sign() {
+        let scalar = [
+            0x17, 0x91, 0x22, 0x63, 0xa5, 0x11, 0xd4, 0x9e, 0x35, 0x9d, 0x1f, 0x8c, 0x88, 0x75,
+            0x1a, 0xcb, 0x34, 0xfa, 0x73, 0x04, 0xea, 0x12, 0x56, 0x5d, 0xa4, 0xb3, 0xee, 0x5d,
+            0x67, 0x85, 0x34, 0x12,
+        ];
+        let original = p256::SecretKey::from_slice(&scalar).unwrap();
+        let pkcs8 = original.to_pkcs8_der().unwrap();
+
+        let imported = passkey_import_pkcs8_core(&B64.encode(pkcs8.as_bytes())).unwrap();
+        assert_eq!(B64.decode(&imported.private_key).unwrap(), scalar);
+
+        let public_point = original.public_key().to_encoded_point(false);
+        let cose = CoseKey::from_slice(&B64.decode(&imported.public_key_cose).unwrap()).unwrap();
+        assert_eq!(cose.kty, KeyType::Assigned(iana::KeyType::EC2));
+        assert_eq!(cose.alg, Some(Algorithm::Assigned(iana::Algorithm::ES256)));
+        assert_eq!(
+            cose.params,
+            vec![
+                (
+                    Label::Int(iana::Ec2KeyParameter::Crv as i64),
+                    Value::from(iana::EllipticCurve::P_256 as u64),
+                ),
+                (
+                    Label::Int(iana::Ec2KeyParameter::X as i64),
+                    Value::Bytes(public_point.x().unwrap().to_vec()),
+                ),
+                (
+                    Label::Int(iana::Ec2KeyParameter::Y as i64),
+                    Value::Bytes(public_point.y().unwrap().to_vec()),
+                ),
+            ]
+        );
+
+        let client_data_hash = B64.encode([0x42u8; 32]);
+        let assertion = passkey_get_assertion_core(
+            "import.example",
+            &imported.private_key,
+            &client_data_hash,
+            true,
+        )
+        .unwrap();
+        let mut signed = B64.decode(&assertion.authenticator_data).unwrap();
+        signed.extend_from_slice(&B64.decode(client_data_hash).unwrap());
+        let signature = Signature::from_der(&B64.decode(assertion.signature).unwrap()).unwrap();
+        let verifying_key = VerifyingKey::from(SigningKey::from(&original));
+        assert!(verifying_key.verify(&signed, &signature).is_ok());
+    }
+
+    #[test]
+    fn import_pkcs8_rejects_malformed_and_wrong_curve_keys() {
+        assert!(passkey_import_pkcs8_core("not base64!").is_err());
+        assert!(passkey_import_pkcs8_core(&B64.encode(b"not DER")).is_err());
+
+        let original = p256::SecretKey::from_slice(&[0x23; 32]).unwrap();
+        let pkcs8 = original.to_pkcs8_der().unwrap();
+        let mut wrong_curve = pkcs8.as_bytes().to_vec();
+        // id-ecPublicKey parameters: prime256v1 (1.2.840.10045.3.1.7).
+        let p256_oid = [0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07];
+        let oid_start = wrong_curve
+            .windows(p256_oid.len())
+            .position(|window| window == p256_oid)
+            .expect("PKCS#8 contains the P-256 curve OID");
+        wrong_curve[oid_start + p256_oid.len() - 1] = 0x01;
+        assert!(passkey_import_pkcs8_core(&B64.encode(wrong_curve)).is_err());
     }
 
     // End-to-end: mint a passkey, assert with it, and verify the signature against

--- a/packages/core/src/adapters/crypto-wasm.test.ts
+++ b/packages/core/src/adapters/crypto-wasm.test.ts
@@ -34,6 +34,7 @@ function fakeWasm() {
 			authenticatorData: "ad",
 			publicKey: "spki",
 		})),
+		passkey_import_pkcs8: vi.fn(() => ({ privateKey: "sk", publicKeyCose: "pk" })),
 		passkey_get_assertion: vi.fn(() => ({ authenticatorData: "ad", signature: "sig" })),
 		open_kdbx4: vi.fn((_file: Uint8Array, _password: string, _keyfile?: Uint8Array) => [
 			{ strings: [] },
@@ -86,6 +87,8 @@ describe("buildCryptoAdapter", () => {
 
 		await a.passkeyMakeCredential("github.com", true);
 		expect(wasm.passkey_make_credential).toHaveBeenCalledWith("github.com", true);
+		await a.passkeyImportPkcs8("pkcs8");
+		expect(wasm.passkey_import_pkcs8).toHaveBeenCalledWith("pkcs8");
 		await a.passkeyGetAssertion("github.com", "sk", "hash", false);
 		expect(wasm.passkey_get_assertion).toHaveBeenCalledWith("github.com", "sk", "hash", false);
 	});

--- a/packages/core/src/adapters/crypto-wasm.ts
+++ b/packages/core/src/adapters/crypto-wasm.ts
@@ -141,6 +141,9 @@ export function buildCryptoAdapter(
 		async passkeyMakeCredential(rpId, userVerified) {
 			return (await getWasm()).passkey_make_credential(rpId, userVerified);
 		},
+		async passkeyImportPkcs8(pkcs8B64) {
+			return (await getWasm()).passkey_import_pkcs8(pkcs8B64);
+		},
 		async passkeyGetAssertion(rpId, privateKeyB64, clientDataHashB64, userVerified) {
 			return (await getWasm()).passkey_get_assertion(
 				rpId,

--- a/packages/core/src/adapters/crypto.ts
+++ b/packages/core/src/adapters/crypto.ts
@@ -34,6 +34,12 @@ export interface PasskeyRegistration {
 	publicKey: string;
 }
 
+/** P-256 PKCS#8 key material converted to Bramble's stored representation. All base64. */
+export interface PasskeyImportResult {
+	privateKey: string;
+	publicKeyCose: string;
+}
+
 /** A passkey assertion: the two parts that require the private key. All base64. */
 export interface PasskeyAssertion {
 	authenticatorData: string;
@@ -146,6 +152,7 @@ export interface CryptoAdapter {
 	// assert signs with the stored private key. Neither needs the VEK loaded; the
 	// private key is decrypted from its entry separately (decryptEntry) first.
 	passkeyMakeCredential(rpId: string, userVerified: boolean): Promise<PasskeyRegistration>;
+	passkeyImportPkcs8(pkcs8B64: string): Promise<PasskeyImportResult>;
 	passkeyGetAssertion(
 		rpId: string,
 		privateKeyB64: string,

--- a/packages/core/src/app/screens/Import/ImportShell.tsx
+++ b/packages/core/src/app/screens/Import/ImportShell.tsx
@@ -120,7 +120,9 @@ export function ImportShell({ onClose }: { onClose?: () => void } = {}) {
 				return;
 			}
 			const raw = p.reads === "text" ? await file.text() : new Uint8Array(await file.arrayBuffer());
-			const res = parseImport(p.id as ImportProvider, raw);
+			const res = await parseImport(p.id as ImportProvider, raw, {
+				passkeyImportPkcs8: (pkcs8StandardB64) => crypto.passkeyImportPkcs8(pkcs8StandardB64),
+			});
 			if (res.imported.length === 0) {
 				// Distinguish an empty file from one where all items failed validation.
 				const noun = res.skipped === 1 ? t`item` : t`items`;

--- a/packages/core/src/hooks/useVault.tsx
+++ b/packages/core/src/hooks/useVault.tsx
@@ -48,20 +48,20 @@ export interface CustomField {
  * security-key unlock in `vault/webauthn-ceremony.ts`. See docs/passkey-provider.md.
  */
 export interface PasskeyCredential {
-	/** Base64url random credential id Bramble minted at creation. */
+	/** Standard-base64 credential id Bramble minted at creation or imported. */
 	credentialId: string;
 	/** Relying-party id, e.g. "github.com". Matched against hostnames. */
 	rpId: string;
 	rpName?: string;
-	/** Base64url `user.id` from the RP. Required for discoverable credentials. */
+	/** Standard-base64 `user.id` from the RP. Required for discoverable credentials. */
 	userHandle: string;
 	userName?: string;
 	userDisplayName?: string;
 	/** COSE algorithm identifier; -7 (ES256) by default. */
 	alg: number;
-	/** Base64url COSE_Key public key the RP verifies against. */
+	/** Standard-base64 COSE_Key public key the RP verifies against. */
 	publicKeyCose: string;
-	/** Base64url PKCS#8 private key. Encrypted at rest with the rest of the entry. */
+	/** Standard-base64 raw P-256 scalar. Encrypted at rest with the rest of the entry. */
 	privateKey: string;
 	/** Always 0: synced passkeys must not increment (a regression reads as a clone). */
 	signCount: number;

--- a/packages/core/src/import/bitwarden.test.ts
+++ b/packages/core/src/import/bitwarden.test.ts
@@ -1,11 +1,46 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseBitwarden } from "./bitwarden";
 
 const json = (obj: unknown) => JSON.stringify(obj);
+// Synthetic P-256 PKCS#8 vector using Bitwarden's exported key encoding.
+const BITWARDEN_TEST_PKCS8_B64URL =
+	"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgBnZeheB_70OqF-B614VjAYBwjGxhQ33Dseb5CSTrH_WhRANCAAQ1mlLzgkRmXz_ixAscFjTFYAc6Jf5-f3_a1Bw2kADusY6Ss6yRf7GMpIXnAwfR9VvTe8NWEd-8epdwMks8hAVx";
+const BITWARDEN_TEST_PKCS8_B64 =
+	"MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgBnZeheB/70OqF+B614VjAYBwjGxhQ33Dseb5CSTrH/WhRANCAAQ1mlLzgkRmXz/ixAscFjTFYAc6Jf5+f3/a1Bw2kADusY6Ss6yRf7GMpIXnAwfR9VvTe8NWEd+8epdwMks8hAVx";
+
+function importContext(
+	convert: (pkcs8StandardB64: string) => Promise<{
+		privateKey: string;
+		publicKeyCose: string;
+	}> = async () => ({ privateKey: "c2NhbGFy", publicKeyCose: "Y29zZQ==" }),
+) {
+	const passkeyImportPkcs8 = vi.fn(convert);
+	return { context: { passkeyImportPkcs8 }, passkeyImportPkcs8 };
+}
+
+function validPasskey(over: Record<string, unknown> = {}) {
+	return {
+		credentialId: "00112233-4455-6677-8899-aabbccddeeff",
+		keyType: "public-key",
+		keyAlgorithm: "ECDSA",
+		keyCurve: "P-256",
+		keyValue: BITWARDEN_TEST_PKCS8_B64URL,
+		rpId: "github.com",
+		rpName: "GitHub",
+		userHandle: "dXNlci1vbmU",
+		userName: "octo",
+		userDisplayName: "Octo Cat",
+		counter: "0",
+		creationDate: "2024-02-03T04:05:06.000Z",
+		discoverable: "true",
+		...over,
+	};
+}
 
 describe("parseBitwarden", () => {
-	it("maps each item type and folds identities into notes", () => {
-		const res = parseBitwarden(
+	it("maps each item type and folds identities into notes", async () => {
+		const { context } = importContext();
+		const res = await parseBitwarden(
 			json({
 				items: [
 					{
@@ -47,6 +82,7 @@ describe("parseBitwarden", () => {
 					{ type: 4, name: "Me", identity: { firstName: "Jane", ssn: "" } },
 				],
 			}),
+			context,
 		);
 
 		expect(res.byType).toEqual({ login: 1, card: 1, note: 2, "ssh-key": 1 });
@@ -77,8 +113,9 @@ describe("parseBitwarden", () => {
 		expect(res.imported[4]?.customFields).toEqual([{ key: "firstName", value: "Jane" }]);
 	});
 
-	it("maps per-URI match detection onto the entry's subdomainMatch", () => {
-		const res = parseBitwarden(
+	it("maps per-URI match detection onto the entry's subdomainMatch", async () => {
+		const { context } = importContext();
+		const res = await parseBitwarden(
 			json({
 				items: [
 					// Default (base domain) / null: stays eTLD+1, so no explicit subdomainMatch.
@@ -105,6 +142,7 @@ describe("parseBitwarden", () => {
 					},
 				],
 			}),
+			context,
 		);
 		const bySubMatch = Object.fromEntries(
 			res.imported.map((e) => [e.name, (e as { subdomainMatch?: string }).subdomainMatch]),
@@ -119,35 +157,309 @@ describe("parseBitwarden", () => {
 		});
 	});
 
-	it("tolerates a login with no uris and warns on passkeys", () => {
-		const res = parseBitwarden(
+	it("imports multiple passkeys and preserves the parent login fields", async () => {
+		const { context, passkeyImportPkcs8 } = importContext();
+		const res = await parseBitwarden(
 			json({
 				items: [
-					{ type: 1, name: "x", login: { username: "u", password: "p", fido2Credentials: [{}] } },
+					{
+						type: 1,
+						name: "GitHub",
+						notes: "keep",
+						creationDate: "2023-01-02T03:04:05.000Z",
+						login: {
+							uris: [{ uri: "https://github.com" }],
+							username: "octo",
+							password: "pw",
+							totp: "otpauth://totp/example",
+							fido2Credentials: [
+								validPasskey(),
+								validPasskey({
+									credentialId: "b64._-4",
+									keyValue: "BQY",
+									userHandle: "dXNlci10d28",
+									userName: null,
+									userDisplayName: null,
+									discoverable: "false",
+								}),
+							],
+						},
+						fields: [{ name: "PIN", value: "1234", type: 1 }],
+					},
 				],
 			}),
+			context,
 		);
-		expect(res.imported[0]).toMatchObject({ type: "login", urls: [] });
-		expect(res.warnings).toHaveLength(1);
+
+		expect(res.skipped).toBe(0);
+		expect(res.warnings).toEqual([]);
+		expect(res.imported).toHaveLength(1);
+		expect(res.imported[0]).toMatchObject({
+			type: "login",
+			name: "GitHub",
+			notes: "keep",
+			urls: ["https://github.com"],
+			username: "octo",
+			password: "pw",
+			totp: "otpauth://totp/example",
+			createdAt: Date.parse("2023-01-02T03:04:05.000Z"),
+			customFields: [{ key: "PIN", value: "1234", hidden: true }],
+			passkeys: [
+				{
+					credentialId: "ABEiM0RVZneImaq7zN3u/w==",
+					rpId: "github.com",
+					rpName: "GitHub",
+					userHandle: "dXNlci1vbmU=",
+					userName: "octo",
+					userDisplayName: "Octo Cat",
+					alg: -7,
+					publicKeyCose: "Y29zZQ==",
+					privateKey: "c2NhbGFy",
+					signCount: 0,
+					createdAt: Date.parse("2024-02-03T04:05:06.000Z"),
+				},
+				{
+					credentialId: "/+4=",
+					userHandle: "dXNlci10d28=",
+				},
+			],
+		});
+		expect(passkeyImportPkcs8.mock.calls).toEqual([[BITWARDEN_TEST_PKCS8_B64], ["BQY="]]);
 	});
 
-	it("rejects non-Bitwarden input", () => {
-		expect(() => parseBitwarden("{}")).toThrow();
-		expect(() => parseBitwarden("not json")).toThrow();
+	it("ignores Bitwarden's discoverability hint and imports every otherwise valid credential", async () => {
+		const { context } = importContext();
+		const res = await parseBitwarden(
+			json({
+				items: [
+					{
+						type: 1,
+						name: "portable",
+						login: {
+							fido2Credentials: [
+								validPasskey({ credentialId: "b64.AQ", discoverable: "true" }),
+								validPasskey({ credentialId: "b64.Ag", discoverable: "false" }),
+								validPasskey({ credentialId: "b64.Aw", discoverable: false }),
+								validPasskey({ credentialId: "b64.BA", discoverable: { malformed: true } }),
+								validPasskey({ credentialId: "b64.BQ", discoverable: undefined }),
+							],
+						},
+					},
+				],
+			}),
+			context,
+		);
+
+		expect(res.warnings).toEqual([]);
+		expect(res.imported[0]).toMatchObject({
+			type: "login",
+			passkeys: [
+				{ credentialId: "AQ==" },
+				{ credentialId: "Ag==" },
+				{ credentialId: "Aw==" },
+				{ credentialId: "BA==" },
+				{ credentialId: "BQ==" },
+			],
+		});
 	});
 
-	it("gives a specific error for an encrypted (password-protected) export", () => {
+	it("skips malformed and unsupported passkeys without dropping the login or valid siblings", async () => {
+		const { context } = importContext(async (pkcs8) => {
+			if (pkcs8 === "cmVqZWN0") throw new Error("synthetic conversion failure");
+			return { privateKey: "c2NhbGFy", publicKeyCose: "Y29zZQ==" };
+		});
+		const res = await parseBitwarden(
+			json({
+				items: [
+					{
+						type: 1,
+						name: "mixed",
+						login: {
+							username: "u",
+							password: "p",
+							fido2Credentials: [
+								validPasskey(),
+								{},
+								validPasskey({ keyCurve: "P-384" }),
+								validPasskey({ userHandle: "" }),
+								validPasskey({ credentialId: "not-a-supported-id" }),
+								validPasskey({ keyValue: "cmVqZWN0" }),
+							],
+						},
+					},
+				],
+			}),
+			context,
+		);
+
+		expect(res.skipped).toBe(0);
+		expect(res.imported[0]).toMatchObject({
+			type: "login",
+			username: "u",
+			password: "p",
+			urls: [],
+			passkeys: [{ credentialId: "ABEiM0RVZneImaq7zN3u/w==" }],
+		});
+		expect(res.warnings).toHaveLength(5);
+		expect(res.warnings.join("\n")).toMatch(/unexpected shape/);
+		expect(res.warnings.join("\n")).toMatch(/unsupported key type, algorithm, or curve/);
+		expect(res.warnings.join("\n")).toMatch(/invalid credential encoding/);
+		expect(res.warnings.join("\n")).toMatch(/invalid private-key material/);
+		expect(res.warnings.join("\n")).not.toContain("cmVqZWN0");
+	});
+
+	it("rejects oversized encoded credential IDs and user handles before conversion", async () => {
+		const { context, passkeyImportPkcs8 } = importContext();
+		const res = await parseBitwarden(
+			json({
+				items: [
+					{
+						type: 1,
+						name: "bounded",
+						login: {
+							username: "keep",
+							password: "parent",
+							fido2Credentials: [
+								validPasskey({ credentialId: `b64.${"A".repeat(1365)}` }),
+								validPasskey({ userHandle: "A".repeat(87) }),
+							],
+						},
+					},
+				],
+			}),
+			context,
+		);
+
+		expect(passkeyImportPkcs8).not.toHaveBeenCalled();
+		expect(res.skipped).toBe(0);
+		expect(res.imported[0]).toMatchObject({
+			type: "login",
+			username: "keep",
+			password: "parent",
+		});
+		const login = res.imported[0];
+		if (login?.type !== "login") throw new Error("expected retained login");
+		expect(login.passkeys).toBeUndefined();
+		expect(res.warnings).toHaveLength(2);
+	});
+
+	it("rejects oversized PKCS#8 before conversion and retains the parent login", async () => {
+		const { context, passkeyImportPkcs8 } = importContext();
+		const res = await parseBitwarden(
+			json({
+				items: [
+					{
+						type: 1,
+						name: "oversized key",
+						login: {
+							username: "keep",
+							password: "parent",
+							// 1,367 base64url chars is larger than the 1 KiB decoded-key ceiling.
+							fido2Credentials: [validPasskey({ keyValue: "A".repeat(1367) })],
+						},
+					},
+				],
+			}),
+			context,
+		);
+
+		expect(passkeyImportPkcs8).not.toHaveBeenCalled();
+		expect(res.skipped).toBe(0);
+		expect(res.imported[0]).toMatchObject({
+			type: "login",
+			username: "keep",
+			password: "parent",
+		});
+		const login = res.imported[0];
+		if (login?.type !== "login") throw new Error("expected retained login");
+		expect(login.passkeys).toBeUndefined();
+		expect(res.warnings).toEqual([
+			'"oversized key" passkey 1 has invalid credential encoding and was skipped.',
+		]);
+	});
+
+	it("normalizes counters and falls back to the parent creation date", async () => {
+		const { context } = importContext();
+		const parentDate = "2022-06-07T08:09:10.000Z";
+		const res = await parseBitwarden(
+			json({
+				items: [
+					{
+						type: 1,
+						name: "dated",
+						creationDate: parentDate,
+						login: {
+							fido2Credentials: [validPasskey({ counter: "12", creationDate: "not a date" })],
+						},
+					},
+				],
+			}),
+			context,
+		);
+
+		expect(res.imported[0]).toMatchObject({
+			type: "login",
+			passkeys: [{ signCount: 0, createdAt: Date.parse(parentDate) }],
+		});
+		expect(res.warnings).toEqual([
+			'"dated" passkey 1 had its signature counter reset to zero.',
+			'"dated" passkey 1 had no valid creation date; a fallback date was used.',
+		]);
+	});
+
+	it("uses one import timestamp when neither credential nor parent has a valid date", async () => {
+		const now = vi.spyOn(Date, "now").mockReturnValue(1_725_000_000_000);
+		const { context } = importContext();
+		try {
+			const res = await parseBitwarden(
+				json({
+					items: [
+						{
+							type: 1,
+							name: "fallback",
+							login: {
+								fido2Credentials: [
+									validPasskey({ creationDate: null }),
+									validPasskey({ creationDate: undefined }),
+								],
+							},
+						},
+					],
+				}),
+				context,
+			);
+			expect(res.imported[0]).toMatchObject({
+				type: "login",
+				passkeys: [{ createdAt: 1_725_000_000_000 }, { createdAt: 1_725_000_000_000 }],
+			});
+		} finally {
+			now.mockRestore();
+		}
+	});
+
+	it("rejects non-Bitwarden input", async () => {
+		const { context } = importContext();
+		await expect(parseBitwarden("{}", context)).rejects.toThrow();
+		await expect(parseBitwarden("not json", context)).rejects.toThrow();
+	});
+
+	it("gives a specific error for an encrypted (password-protected) export", async () => {
+		const { context } = importContext();
 		// The password-protected format: no `items`, an opaque `data` blob, `encrypted: true`.
 		const enc = json({ encrypted: true, passwordProtected: true, salt: "x", data: "2.abc|def" });
-		expect(() => parseBitwarden(enc)).toThrow(/encrypted \(password-protected\)/i);
+		await expect(parseBitwarden(enc, context)).rejects.toThrow(/encrypted \(password-protected\)/i);
 		// passwordProtected alone (some exports omit `encrypted`) is caught too.
-		expect(() => parseBitwarden(json({ passwordProtected: true, data: "x" }))).toThrow(
-			/encrypted/i,
-		);
+		await expect(
+			parseBitwarden(json({ passwordProtected: true, data: "x" }), context),
+		).rejects.toThrow(/encrypted/i);
 	});
 
-	it("does not misfire on an unencrypted export (encrypted: false)", () => {
-		const res = parseBitwarden(json({ encrypted: false, items: [{ type: 2, name: "n" }] }));
+	it("does not misfire on an unencrypted export (encrypted: false)", async () => {
+		const { context } = importContext();
+		const res = await parseBitwarden(
+			json({ encrypted: false, items: [{ type: 2, name: "n" }] }),
+			context,
+		);
 		expect(res.imported).toHaveLength(1);
 	});
 });

--- a/packages/core/src/import/bitwarden.ts
+++ b/packages/core/src/import/bitwarden.ts
@@ -1,10 +1,11 @@
 import { z } from "zod";
 import type { SubdomainMatchMode } from "../adapters/autofill";
-import type { EntryData } from "../hooks/useVault";
+import type { EntryData, PasskeyCredential } from "../hooks/useVault";
+import { base64UrlToBase64, base64UrlToBytes, bytesToBase64, hexToBytes } from "../util/bytes";
 import { cardBrand } from "../util/card";
 import { deriveKeyType } from "../util/ssh";
 import { asText, type RawField, summarize, toCustomFields } from "./shared";
-import type { ImportResult } from "./types";
+import type { ImportParserContext, ImportResult } from "./types";
 
 // Lenient schema for unencrypted Bitwarden JSON: only `items` is required.
 // https://bitwarden.com/help/condition-bitwarden-import/
@@ -17,6 +18,7 @@ const itemSchema = z.object({
 	type: z.number().nullish(), // 1 login, 2 secureNote, 3 card, 4 identity, 5 sshKey
 	name: z.string().nullish(),
 	notes: z.string().nullish(),
+	creationDate: z.string().nullish(),
 	fields: z.array(fieldSchema).nullish(),
 	login: z
 		.object({
@@ -45,6 +47,23 @@ const itemSchema = z.object({
 });
 const exportSchema = z.object({ items: z.array(itemSchema) });
 
+// Validate credentials independently so one malformed child never rejects its parent login.
+const passkeySchema = z.object({
+	credentialId: z.string(),
+	keyType: z.string(),
+	keyAlgorithm: z.string(),
+	keyCurve: z.string(),
+	keyValue: z.string(),
+	rpId: z.string(),
+	rpName: z.string().nullish(),
+	userHandle: z.string(),
+	userName: z.string().nullish(),
+	userDisplayName: z.string().nullish(),
+	counter: z.string().nullish(),
+	creationDate: z.string().nullish(),
+});
+// Ignore `discoverable` so Bramble preserves every otherwise valid credential.
+
 type BwField = z.infer<typeof fieldSchema>;
 
 const FORMAT_ERROR = "This doesn't look like a Bitwarden JSON export.";
@@ -53,6 +72,154 @@ const FORMAT_ERROR = "This doesn't look like a Bitwarden JSON export.";
 // array - so it would otherwise trip FORMAT_ERROR and look like "not Bitwarden".
 const ENCRYPTED_ERROR =
 	'This is an encrypted (password-protected) Bitwarden export. Re-export from Bitwarden as a plain .json with "Password protected" turned off, then import that file.';
+
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+const UUID = /^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$/i;
+const MAX_CREDENTIAL_ID_BYTES = 1023;
+const MAX_USER_HANDLE_BYTES = 64;
+const MAX_RP_ID_LENGTH = 253;
+// Cap bridge input at 1 KiB while allowing optional PKCS#8 metadata.
+const MAX_PKCS8_BYTES = 1024;
+
+function maxBase64UrlLength(decodedBytes: number): number {
+	return Math.ceil((decodedBytes * 4) / 3);
+}
+
+function strictBase64Url(value: string, maxDecodedBytes: number): string {
+	if (
+		value.length > maxBase64UrlLength(maxDecodedBytes) ||
+		!BASE64URL.test(value) ||
+		value.length % 4 === 1
+	) {
+		throw new Error("invalid base64url");
+	}
+	return value;
+}
+
+function credentialIdToBase64(value: string): string {
+	let bytes: Uint8Array;
+	const uuid = UUID.exec(value);
+	if (uuid) {
+		bytes = hexToBytes(uuid.slice(1).join(""));
+	} else if (value.startsWith("b64.")) {
+		if (value.length > 4 + maxBase64UrlLength(MAX_CREDENTIAL_ID_BYTES)) {
+			throw new Error("credential id outside supported bounds");
+		}
+		const encoded = value.slice(4);
+		bytes = base64UrlToBytes(strictBase64Url(encoded, MAX_CREDENTIAL_ID_BYTES));
+	} else {
+		throw new Error("unsupported credential id");
+	}
+	if (bytes.length === 0 || bytes.length > MAX_CREDENTIAL_ID_BYTES) {
+		throw new Error("credential id outside supported bounds");
+	}
+	return bytesToBase64(bytes);
+}
+
+function userHandleToBase64(value: string): string {
+	const bytes = base64UrlToBytes(strictBase64Url(value, MAX_USER_HANDLE_BYTES));
+	if (bytes.length === 0 || bytes.length > MAX_USER_HANDLE_BYTES) {
+		throw new Error("user handle outside supported bounds");
+	}
+	return bytesToBase64(bytes);
+}
+
+function pkcs8ToStandardBase64(value: string): string {
+	return base64UrlToBase64(strictBase64Url(value, MAX_PKCS8_BYTES));
+}
+
+function parseDate(value: string | null | undefined): number | undefined {
+	if (!value) return undefined;
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function validRpId(value: string): boolean {
+	if (value.length === 0 || value.length > MAX_RP_ID_LENGTH) return false;
+	return value
+		.split(".")
+		.every((label) => /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(label));
+}
+
+async function importPasskeys(
+	rawCredentials: unknown[] | null | undefined,
+	loginName: string,
+	parentCreatedAt: number | undefined,
+	importedAt: number,
+	context: ImportParserContext,
+	warnings: string[],
+): Promise<PasskeyCredential[] | undefined> {
+	if (!rawCredentials?.length) return undefined;
+
+	const imported: PasskeyCredential[] = [];
+	for (const [index, raw] of rawCredentials.entries()) {
+		const label = `"${loginName}" passkey ${index + 1}`;
+		const parsed = passkeySchema.safeParse(raw);
+		if (!parsed.success) {
+			warnings.push(`${label} had an unexpected shape and was skipped.`);
+			continue;
+		}
+		const credential = parsed.data;
+		if (
+			credential.keyType !== "public-key" ||
+			credential.keyAlgorithm !== "ECDSA" ||
+			credential.keyCurve !== "P-256"
+		) {
+			warnings.push(`${label} uses an unsupported key type, algorithm, or curve and was skipped.`);
+			continue;
+		}
+		if (!validRpId(credential.rpId)) {
+			warnings.push(`${label} has an invalid relying-party ID and was skipped.`);
+			continue;
+		}
+
+		let credentialId: string;
+		let userHandle: string;
+		let pkcs8: string;
+		try {
+			credentialId = credentialIdToBase64(credential.credentialId);
+			userHandle = userHandleToBase64(credential.userHandle);
+			pkcs8 = pkcs8ToStandardBase64(credential.keyValue);
+		} catch {
+			warnings.push(`${label} has invalid credential encoding and was skipped.`);
+			continue;
+		}
+
+		let key: Awaited<ReturnType<ImportParserContext["passkeyImportPkcs8"]>>;
+		try {
+			key = await context.passkeyImportPkcs8(pkcs8);
+			if (!key.privateKey || !key.publicKeyCose) throw new Error("empty converted key");
+		} catch {
+			// Suppress foreign conversion errors so they cannot leak key bytes into the UI.
+			warnings.push(`${label} has invalid private-key material and was skipped.`);
+			continue;
+		}
+
+		const credentialCreatedAt = parseDate(credential.creationDate);
+		imported.push({
+			credentialId,
+			rpId: credential.rpId,
+			rpName: credential.rpName || undefined,
+			userHandle,
+			userName: credential.userName || undefined,
+			userDisplayName: credential.userDisplayName || undefined,
+			alg: -7,
+			publicKeyCose: key.publicKeyCose,
+			privateKey: key.privateKey,
+			signCount: 0,
+			createdAt: credentialCreatedAt ?? parentCreatedAt ?? importedAt,
+		});
+
+		if (credential.counter != null && credential.counter !== "0") {
+			warnings.push(`${label} had its signature counter reset to zero.`);
+		}
+		if (credentialCreatedAt === undefined) {
+			warnings.push(`${label} had no valid creation date; a fallback date was used.`);
+		}
+	}
+
+	return imported.length ? imported : undefined;
+}
 
 /**
  * Map Bitwarden's per-URI match detection onto our per-entry `subdomainMatch`. Bitwarden's
@@ -77,7 +244,10 @@ function mapFields(fields: BwField[] | null | undefined): RawField[] {
 }
 
 /** Parse an unencrypted Bitwarden JSON export into Bramble entries. Throws on non-Bitwarden input. */
-export function parseBitwarden(raw: string | Uint8Array): ImportResult {
+export async function parseBitwarden(
+	raw: string | Uint8Array,
+	context: ImportParserContext,
+): Promise<ImportResult> {
 	let json: unknown;
 	try {
 		json = JSON.parse(asText(raw));
@@ -95,17 +265,24 @@ export function parseBitwarden(raw: string | Uint8Array): ImportResult {
 
 	const imported: EntryData[] = [];
 	const warnings: string[] = [];
+	const importedAt = Date.now();
 
 	for (const item of parsed.data.items) {
 		const name = item.name ?? "";
 		const notes = item.notes || undefined;
 		const fields = mapFields(item.fields);
+		const createdAt = parseDate(item.creationDate);
 
 		if (item.type === 1) {
 			const login = item.login ?? {};
-			if (login.fido2Credentials?.length) {
-				warnings.push(`"${name}" has a passkey, which can't be imported yet.`);
-			}
+			const passkeys = await importPasskeys(
+				login.fido2Credentials,
+				name,
+				createdAt,
+				importedAt,
+				context,
+				warnings,
+			);
 			// Keep all URLs; collapse their per-URI match detection into one per-entry mode.
 			const urls = (login.uris ?? [])
 				.map((u) => u.uri)
@@ -120,6 +297,8 @@ export function parseBitwarden(raw: string | Uint8Array): ImportResult {
 				totp: login.totp || undefined,
 				subdomainMatch: subdomainMatchFor(login.uris),
 				customFields: toCustomFields(fields),
+				createdAt,
+				passkeys,
 			});
 		} else if (item.type === 3) {
 			const card = item.card ?? {};

--- a/packages/core/src/import/index.ts
+++ b/packages/core/src/import/index.ts
@@ -3,10 +3,10 @@ import { parseApplePasswords, parseGooglePasswords } from "./csv";
 import { parseKeePass } from "./keepass";
 import { parseOnePassword } from "./onepassword";
 import { parseProtonPass } from "./protonpass";
-import type { ImportParser, ImportProvider, ImportResult } from "./types";
+import type { ImportParser, ImportParserContext, ImportProvider, ImportResult } from "./types";
 
 export { kdbxEntriesToResult } from "./kdbx";
-export type { ImportProvider, ImportResult } from "./types";
+export type { ImportParserContext, ImportProvider, ImportResult } from "./types";
 export {
 	parseApplePasswords,
 	parseBitwarden,
@@ -95,6 +95,10 @@ export const IMPORT_PROVIDERS: readonly ImportProviderInfo[] = [
 ];
 
 /** Parse a provider export into normalized entries. Read the file as the provider's `reads` kind. */
-export function parseImport(provider: ImportProvider, raw: string | Uint8Array): ImportResult {
-	return PARSERS[provider](raw);
+export function parseImport(
+	provider: ImportProvider,
+	raw: string | Uint8Array,
+	context: ImportParserContext,
+): ImportResult | Promise<ImportResult> {
+	return PARSERS[provider](raw, context);
 }

--- a/packages/core/src/import/types.ts
+++ b/packages/core/src/import/types.ts
@@ -1,6 +1,7 @@
+import type { PasskeyImportResult } from "../adapters/crypto";
 import type { EntryData, EntryType } from "../hooks/useVault";
 
-/** Password managers we can read a (synchronous) export from. */
+/** Password managers whose plaintext/container exports Bramble can read. */
 export type ImportProvider =
 	| "bitwarden"
 	| "onepassword"
@@ -17,5 +18,13 @@ export interface ImportResult {
 	warnings: string[];
 }
 
-/** Pure parser: string for text formats (JSON/XML), bytes for containers (.1pux/.zip). */
-export type ImportParser = (raw: string | Uint8Array) => ImportResult;
+/** Narrow async services available to importers; ordinary parsers ignore this context. */
+export interface ImportParserContext {
+	passkeyImportPkcs8(pkcs8StandardB64: string): Promise<PasskeyImportResult>;
+}
+
+/** String for text formats, bytes for containers. Crypto-backed parsers may be asynchronous. */
+export type ImportParser = (
+	raw: string | Uint8Array,
+	context: ImportParserContext,
+) => ImportResult | Promise<ImportResult>;

--- a/packages/core/src/wasm.ts
+++ b/packages/core/src/wasm.ts
@@ -7,6 +7,7 @@
 import type {
 	EncryptedPayload,
 	PasskeyAssertion,
+	PasskeyImportResult,
 	PasskeyRegistration,
 	PasswordSlotBlob,
 	VekEncrypted,
@@ -87,6 +88,7 @@ export interface VaultCrypto {
 	decrypt_with_vek(iv: string, ciphertext: string): Awaitable<string>;
 
 	passkey_make_credential(rpId: string, userVerified: boolean): Awaitable<PasskeyRegistration>;
+	passkey_import_pkcs8(pkcs8B64: string): Awaitable<PasskeyImportResult>;
 	passkey_get_assertion(
 		rpId: string,
 		privateKeyB64: string,

--- a/packages/platform-extension/src/crypto.ts
+++ b/packages/platform-extension/src/crypto.ts
@@ -6,6 +6,7 @@ import type {
 	KdbxRawEntry,
 	OpenKdbxInput,
 	PasskeyAssertion,
+	PasskeyImportResult,
 	PasskeyRegistration,
 	PasswordSlotBlob,
 	SaveKdbxInput,
@@ -24,6 +25,7 @@ import type {
 	CryptoEncrypt,
 	CryptoEncryptOuter,
 	CryptoPasskeyGet,
+	CryptoPasskeyImportPkcs8,
 	CryptoPasskeyMake,
 	CryptoUnlockWithVek,
 	CryptoUnwrapPasswordSlot,
@@ -188,6 +190,10 @@ function makeCrypto(vaultId?: string): CryptoAdapter {
 				clientDataHashB64,
 				userVerified,
 			} satisfies CryptoPasskeyGet),
+		passkeyImportPkcs8: (pkcs8B64) =>
+			send<PasskeyImportResult>("CRYPTO_PASSKEY_IMPORT_PKCS8", {
+				pkcs8B64,
+			} satisfies CryptoPasskeyImportPkcs8),
 	};
 }
 

--- a/packages/platform-extension/src/crypto/messages.ts
+++ b/packages/platform-extension/src/crypto/messages.ts
@@ -90,6 +90,9 @@ export const CryptoPasskeyGetSchema = z.object({
 	clientDataHashB64: z.string(),
 	userVerified: z.boolean(),
 });
+export const CryptoPasskeyImportPkcs8Schema = z.object({
+	pkcs8B64: z.string(),
+});
 
 export type CryptoUnlockWithVek = z.infer<typeof CryptoUnlockWithVekSchema>;
 export type CryptoWrapPasswordSlot = z.infer<typeof CryptoWrapPasswordSlotSchema>;
@@ -107,3 +110,4 @@ export type CryptoOpenKdbx = z.infer<typeof CryptoOpenKdbxSchema>;
 export type CryptoSaveKdbx = z.infer<typeof CryptoSaveKdbxSchema>;
 export type CryptoPasskeyMake = z.infer<typeof CryptoPasskeyMakeSchema>;
 export type CryptoPasskeyGet = z.infer<typeof CryptoPasskeyGetSchema>;
+export type CryptoPasskeyImportPkcs8 = z.infer<typeof CryptoPasskeyImportPkcs8Schema>;

--- a/packages/platform-extension/src/offscreen-core.ts
+++ b/packages/platform-extension/src/offscreen-core.ts
@@ -28,6 +28,7 @@ import {
 	CryptoEncryptSchema,
 	CryptoOpenKdbxSchema,
 	CryptoPasskeyGetSchema,
+	CryptoPasskeyImportPkcs8Schema,
 	CryptoPasskeyMakeSchema,
 	CryptoSaveKdbxSchema,
 	CryptoUnlockWithVekSchema,
@@ -338,6 +339,10 @@ async function dispatchCrypto(a: CryptoAdapter, type: string, payload: unknown):
 		case "CRYPTO_PASSKEY_GET": {
 			const p = CryptoPasskeyGetSchema.parse(payload);
 			return a.passkeyGetAssertion(p.rpId, p.privateKeyB64, p.clientDataHashB64, p.userVerified);
+		}
+		case "CRYPTO_PASSKEY_IMPORT_PKCS8": {
+			const p = CryptoPasskeyImportPkcs8Schema.parse(payload);
+			return a.passkeyImportPkcs8(p.pkcs8B64);
 		}
 
 		default:

--- a/packages/platform-extension/src/offscreen-passkey-import.test.ts
+++ b/packages/platform-extension/src/offscreen-passkey-import.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { calls, stub } = vi.hoisted(() => {
+	const calls: string[] = [];
+	const stub = {
+		passkey_import_pkcs8: (pkcs8B64: string) => {
+			calls.push(pkcs8B64);
+			return { privateKey: "c2NhbGFy", publicKeyCose: "Y29zZQ==" };
+		},
+	};
+	return { calls, stub };
+});
+
+vi.mock("./wasm-loader", () => ({ loadWasm: async () => stub }));
+
+import { handleHostMessage } from "./offscreen-core";
+
+describe("offscreen CRYPTO_PASSKEY_IMPORT_PKCS8", () => {
+	it("validates and forwards the PKCS#8 value to the crypto adapter", async () => {
+		calls.length = 0;
+		const res = await handleHostMessage("CRYPTO_PASSKEY_IMPORT_PKCS8", {
+			pkcs8B64: "cGtjczg=",
+		});
+
+		expect(res).toEqual({
+			ok: true,
+			data: { privateKey: "c2NhbGFy", publicKeyCose: "Y29zZQ==" },
+		});
+		expect(calls).toEqual(["cGtjczg="]);
+	});
+
+	it("rejects a malformed transport payload before calling crypto", async () => {
+		calls.length = 0;
+		const res = await handleHostMessage("CRYPTO_PASSKEY_IMPORT_PKCS8", {});
+
+		expect(res.ok).toBe(false);
+		expect(calls).toEqual([]);
+	});
+});

--- a/packages/platform-mobile/android/app/src/main/java/app/bramble/mobile/NativeCryptoPlugin.kt
+++ b/packages/platform-mobile/android/app/src/main/java/app/bramble/mobile/NativeCryptoPlugin.kt
@@ -264,6 +264,21 @@ class NativeCryptoPlugin : Plugin() {
         }
     }
 
+    // --- passkey import ---
+
+    @PluginMethod
+    fun passkeyImportPkcs8(call: PluginCall) {
+        val pkcs8 = str(call, "pkcs8B64") ?: return
+        call.runCrypto {
+            val imported = uniffi.vault_crypto.passkeyImportPkcs8(pkcs8)
+            call.resolve(
+                JSObject()
+                    .put("privateKey", imported.privateKey)
+                    .put("publicKeyCose", imported.publicKeyCose)
+            )
+        }
+    }
+
     // --- KDBX4 import ---
 
     @PluginMethod

--- a/packages/platform-mobile/ios/App/App/NativeCrypto.swift
+++ b/packages/platform-mobile/ios/App/App/NativeCrypto.swift
@@ -32,6 +32,7 @@ public class NativeCryptoPlugin: CAPPlugin, CAPBridgedPlugin {
 		CAPPluginMethod(name: "decryptEntries", returnType: CAPPluginReturnPromise),
 		CAPPluginMethod(name: "encryptWithVek", returnType: CAPPluginReturnPromise),
 		CAPPluginMethod(name: "decryptWithVek", returnType: CAPPluginReturnPromise),
+		CAPPluginMethod(name: "passkeyImportPkcs8", returnType: CAPPluginReturnPromise),
 		CAPPluginMethod(name: "openKdbx4", returnType: CAPPluginReturnPromise),
 		// Sync transport: Noise handshake (KK roster-auth + XXpsk3 enrollment) + Nostr.
 		CAPPluginMethod(name: "handshakeGenerateKeypair", returnType: CAPPluginReturnPromise),
@@ -252,6 +253,16 @@ public class NativeCryptoPlugin: CAPPlugin, CAPBridgedPlugin {
 		guard let iv = str(call, "ivB64"), let ct = str(call, "ciphertextB64") else { return }
 		do {
 			call.resolve(["value": try App.decryptWithVek(ivB64: iv, ciphertextB64: ct)])
+		} catch { fail(call, error) }
+	}
+
+	// --- passkey import ---
+
+	@objc func passkeyImportPkcs8(_ call: CAPPluginCall) {
+		guard let pkcs8 = str(call, "pkcs8B64") else { return }
+		do {
+			let imported = try App.passkeyImportPkcs8(pkcs8B64: pkcs8)
+			call.resolve(["privateKey": imported.privateKey, "publicKeyCose": imported.publicKeyCose])
 		} catch { fail(call, error) }
 	}
 

--- a/packages/platform-mobile/src/native-crypto.ts
+++ b/packages/platform-mobile/src/native-crypto.ts
@@ -8,6 +8,7 @@ import { registerPlugin } from "@capacitor/core";
 import type {
 	EncryptedPayload,
 	PasskeyAssertion,
+	PasskeyImportResult,
 	PasskeyRegistration,
 	PasswordSlotBlob,
 	VekEncrypted,
@@ -86,6 +87,7 @@ interface NativeCryptoPlugin {
 		clientDataHashB64: string;
 		userVerified: boolean;
 	}): Promise<PasskeyAssertion>;
+	passkeyImportPkcs8(o: { pkcs8B64: string }): Promise<PasskeyImportResult>;
 	openKdbx4(o: {
 		fileB64: string;
 		password: string;
@@ -239,6 +241,7 @@ const nativeModule: VaultCrypto = {
 		Native.passkeyMakeCredential({ rpId, userVerified }),
 	passkey_get_assertion: (rpId, privateKeyB64, clientDataHashB64, userVerified) =>
 		Native.passkeyGetAssertion({ rpId, privateKeyB64, clientDataHashB64, userVerified }),
+	passkey_import_pkcs8: (pkcs8B64) => Native.passkeyImportPkcs8({ pkcs8B64 }),
 
 	open_kdbx4: async (file, password, keyfile) =>
 		(


### PR DESCRIPTION
All of the below writted by GPT-5.6 (implementation was thoughtfully planned, scoped, and orchestrated with multiple agents to avoid a slop pr to the best of my ability):

Closes #30

## Summary

This imports supported passkeys from plaintext Bitwarden JSON exports while preserving the existing behavior for passwords, URLs, TOTP, notes, and custom fields.

- Adds a narrow Rust P-256 PKCS#8 conversion function and reuses the same ES256 COSE construction as newly created Bramble passkeys.
- Exposes that conversion through WASM, UniFFI/native adapters, the extension offscreen RPC, and the iOS/Android Capacitor bridges.
- Makes the Bitwarden parser async through a small injected crypto callback; other importers remain synchronous internally.
- Handles each exported passkey independently, including both UUID and `b64.<base64url>` credential-ID forms.
- Bounds inputs, zeroizes temporary secret bytes, sanitizes warnings, resets nonzero counters to `0`, and falls back safely for invalid creation dates.

No dependencies, lockfiles, generated bindings, build artifacts, or planning files are included.

## Scope and intentional behavior

The first slice supports plaintext Bitwarden JSON containing `public-key` / ECDSA / P-256 credentials only. CSV, encrypted JSON, other curves/algorithms, and FIDO Credential Exchange are out of scope.

Bitwarden's `discoverable` hint is intentionally ignored. Bramble has no corresponding stored lookup flag, so credentials marked `discoverable: false` are promoted into Bramble's existing discoverable model. This makes full import work and retains allow-list use with the same credential ID/keypair, but may additionally expose the credential in username-less or conditional pickers. RP-ID matching and Bramble's normal unlock/approval flow are unchanged.

A malformed or unsupported passkey produces a non-secret warning and is skipped individually. It cannot discard the parent login or a valid sibling passkey.

## Security and privacy

Key conversion stays in the existing Rust crypto layer using dependencies Bramble already ships; there is no JavaScript DER/CBOR implementation. Temporary DER/scalar buffers are zeroized, key inputs are length-bounded, and foreign parser errors are not copied into UI warnings. The importer never includes private-key material, user handles, or raw credential IDs in warning text.

Bitwarden plaintext exports contain sensitive private keys. Once imported, Bramble encrypts the passkey material with the rest of the vault entry.

## Validation

The full gate was reproduced after rebasing with the pinned toolchain: Node 24.18.0, pnpm 10.33.0, Rust 1.95.0, and wasm-pack 0.13.1.

The checks below were run locally. At publication, upstream CI and CodeQL are awaiting maintainer approval for this fork PR.

- Core suite: **492/492**
- Extension suite: **418/418**
- Mobile suite: **45/45**
- Focused core importer/adapter tests: **19/19**
- Extension RPC tests: **2/2**
- Focused Rust passkey tests: **6/6**
- Full Rust library: **51 passed, 2 existing ignored**
- Repository TypeScript typecheck: passed
- Biome `ci:check`: **441 files passed**
- Extracted i18n check: passed
- Locked WASM build and behavioral verification: passed
- Direct generated-WASM conversion of a synthetic P-256 PKCS#8 fixture in Bitwarden export encoding: returned a 32-byte scalar and 77-byte COSE key
- FFI library check and UniFFI signature generation: passed
- Chromium and Firefox production builds: passed
- `web-ext lint`: **0 errors, 0 notices** (9 existing/nonblocking bundle or manifest warnings)
- `git diff --check`: passed

A disposable LibreWolf 153 profile was used for a full UI smoke test with the synthetic fixture in Bitwarden export encoding and exact `discoverable: false`. The extension created a vault, previewed one item with zero warnings, imported it, and displayed user `octo`, RP ID `github.com`, and the passkey edit control. No normal browser profile was touched.

## Known validation gaps

Generated UniFFI method/result signatures match the handwritten Swift/Kotlin bridge calls. The bridges have not yet been compiled and exercised against freshly generated native artifacts on Android/macOS toolchains. Normal fork PR CI does not cover that gap.

No live relying-party authentication was performed. Rust sign/verify coverage validates the converted keypair cryptographically; the LibreWolf smoke validates import, persistence, and display.

## Suggested review order

1. Rust PKCS#8 conversion, zeroization, and shared COSE construction
2. Bitwarden field mapping, validation bounds, warning/failure semantics, and discoverability promotion
3. Async importer context and UI invocation
4. WASM and extension offscreen transport
5. UniFFI and handwritten Swift/Kotlin bridges
