### PR TITLE
fix(autofill): narrow the login picker as the user types a username

### DIFF
--- a/docs/autofill.md
+++ b/docs/autofill.md
@@ -123,6 +123,9 @@ could read it. Instead:
 
 1. On focusing a candidate field, the dropdown shows the matching entries
    (`query` returns only summaries: name plus a username or masked `•••• 1234`).
+   Typing into the username field narrows the list to entries whose saved
+   username matches; a value the field already held before the user typed
+   (a page pre-fill, an autofocus default) does not count as a search.
 2. The user picks one.
 3. Only then does the page-bound `AUTOFILL_SELECT` response return the actual
    secrets for that entry.

--- a/packages/platform-extension/src/content/content.dom.test.ts
+++ b/packages/platform-extension/src/content/content.dom.test.ts
@@ -42,12 +42,19 @@ let onSuggestedCb: (() => void) | null = null;
 let regenerateCb: (() => void) | null = null;
 let unlockCb: ((field: HTMLInputElement | null) => void) | null = null;
 let pickCb: ((entryId: string, otpOnly: boolean) => void) | null = null;
+// Models picker.removeDropdown()'s real behavior: on a normal (iframe-mode) site it is a
+// no-op against the visible row, it only clears the anchor. A call site that relies on this
+// alone to hide the picker leaves the row on screen; asserting on `pickerState.host` (not just
+// which mock fired) is what catches that class of regression.
+const removeDropdown = vi.fn(() => {
+	pickerState.anchor = null;
+});
 vi.mock("./picker", () => ({
 	picker: {
 		showMatches,
 		showLocked,
 		remove: removePicker,
-		removeDropdown: vi.fn(),
+		removeDropdown,
 		reposition: vi.fn(),
 		activeHost: () => pickerState.host,
 		anchorField: () => pickerState.anchor,
@@ -552,6 +559,163 @@ describe("content: strong-password suggestion on signup", () => {
 		pass.focus();
 		send({ type: "AUTOFILL_MATCHES", payload: result({ logins: [] }) });
 		expect(lastSuggest()).toBeUndefined();
+	});
+});
+
+describe("content: username filter on login picker", () => {
+	const logins = [
+		{ id: "1", name: "GitHub", secondary: "alice@example.com" },
+		{ id: "2", name: "GitHub", secondary: "bob@example.com" },
+		{ id: "3", name: "Work", secondary: "alice.work@corp.com" },
+	];
+
+	beforeEach(() => {
+		showMatches.mockClear();
+		removeDropdown.mockClear();
+		removePicker.mockClear();
+		pickerState.host = null;
+		pickerState.anchor = null;
+		pendingQueryResponses.length = 0;
+		document.body.innerHTML = `
+			<form>
+				<input id="user" type="email" name="email" autocomplete="username" />
+				<input id="pass" type="password" name="password" autocomplete="current-password" />
+			</form>`;
+		invalidatePageFields();
+	});
+
+	it("shows all logins when the username field is empty", () => {
+		const user = document.getElementById("user") as HTMLInputElement;
+		user.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins }) });
+		expect(showMatches.mock.calls.at(-1)?.[0]).toEqual(logins);
+	});
+
+	it("narrows options as the user types in the username field", () => {
+		const user = document.getElementById("user") as HTMLInputElement;
+		user.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins }) });
+		showMatches.mockClear();
+
+		user.value = "alice";
+		dispatchTrustedInteraction("input", user);
+		expect(showMatches.mock.calls.at(-1)?.[0]).toEqual([
+			{ id: "1", name: "GitHub", secondary: "alice@example.com" },
+			{ id: "3", name: "Work", secondary: "alice.work@corp.com" },
+		]);
+	});
+
+	it("still shows the single row when typing narrows to exactly one match", () => {
+		// Narrowing to the entry you want is the most useful moment to keep it on screen: hiding
+		// it here would leave no way back to a different account short of clearing the field.
+		const user = document.getElementById("user") as HTMLInputElement;
+		user.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins }) });
+		showMatches.mockClear();
+		removePicker.mockClear();
+
+		user.value = "bob@example.com";
+		dispatchTrustedInteraction("input", user);
+		expect(showMatches.mock.calls.at(-1)?.[0]).toEqual([
+			{ id: "2", name: "GitHub", secondary: "bob@example.com" },
+		]);
+		expect(removePicker).not.toHaveBeenCalled();
+	});
+
+	it("matches either direction: a query typed past the stored value", () => {
+		// A second, unrelated entry keeps the total above one so the static "nothing to
+		// disambiguate" rule doesn't preempt filtering.
+		const twoLogins = [
+			{ id: "1", name: "Example", secondary: "alice" },
+			{ id: "2", name: "Other", secondary: "someone@other.com" },
+		];
+		const user = document.getElementById("user") as HTMLInputElement;
+		user.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins: twoLogins }) });
+		showMatches.mockClear();
+
+		user.value = "alice@example.com";
+		dispatchTrustedInteraction("input", user);
+		expect(showMatches.mock.calls.at(-1)?.[0]).toEqual([
+			{ id: "1", name: "Example", secondary: "alice" },
+		]);
+	});
+
+	it("does not match by entry name alone", () => {
+		const user = document.getElementById("user") as HTMLInputElement;
+		user.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins }) });
+		showMatches.mockClear();
+		removePicker.mockClear();
+
+		// Both entries are named "GitHub", but neither saved username contains "git".
+		user.value = "git";
+		dispatchTrustedInteraction("input", user);
+		expect(showMatches).not.toHaveBeenCalled();
+		expect(removePicker).toHaveBeenCalled();
+	});
+
+	it("fully dismisses the picker (not just the shadow renderer) when nothing matches", () => {
+		const user = document.getElementById("user") as HTMLInputElement;
+		user.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins }) });
+		showMatches.mockClear();
+		removePicker.mockClear();
+
+		user.value = "zzzz";
+		dispatchTrustedInteraction("input", user);
+		expect(showMatches).not.toHaveBeenCalled();
+		// picker.remove() (+ dropRelayed()), not picker.removeDropdown(): the latter is a no-op
+		// against the primary iframe renderer and would leave the row on screen.
+		expect(removePicker).toHaveBeenCalled();
+		expect(pickerState.host).toBeNull();
+	});
+
+	it("does not filter logins while typing in the password field", () => {
+		const pass = document.getElementById("pass") as HTMLInputElement;
+		pass.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins }) });
+		showMatches.mockClear();
+
+		pass.value = "alice";
+		dispatchTrustedInteraction("input", pass);
+		expect(showMatches.mock.calls.at(-1)?.[0]).toEqual(logins);
+	});
+
+	it("does not filter a pre-filled value the user never typed", () => {
+		// A remembered email pre-filled by the page (or an autofocus default) sets field.value
+		// without the user ever typing: it must not be treated as a search.
+		const user = document.getElementById("user") as HTMLInputElement;
+		user.value = "zzzz";
+		user.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins }) });
+		expect(showMatches.mock.calls.at(-1)?.[0]).toEqual(logins);
+	});
+
+	it("hides the picker while typing when the site has exactly one saved login", () => {
+		// The static "nothing to disambiguate" rule, kept deliberately separate from filtering:
+		// this must keep working even though the filtered-narrows-to-one case now shows a row
+		// instead of hiding.
+		const oneLogin = [{ id: "1", name: "GitHub", secondary: "alice@example.com" }];
+		const user = document.getElementById("user") as HTMLInputElement;
+		user.focus();
+		send({ type: "VAULT_LOCK_STATE", payload: { locked: false } });
+		send({ type: "AUTOFILL_MATCHES", payload: result({ logins: oneLogin }) });
+		showMatches.mockClear();
+		removePicker.mockClear();
+
+		user.value = "a";
+		dispatchTrustedInteraction("input", user);
+		expect(showMatches).not.toHaveBeenCalled();
+		expect(removePicker).toHaveBeenCalled();
 	});
 });
 

--- a/packages/platform-extension/src/content/content.ts
+++ b/packages/platform-extension/src/content/content.ts
@@ -452,6 +452,35 @@ function regenerateInto(field: HTMLInputElement): string {
 	return password;
 }
 
+/**
+ * Case-insensitive, either-direction prefix match against the saved username: covers both
+ * a query typed further than the stored value (`alice` -> `alice@example.com`) and a stored
+ * value longer than what's typed so far. Entry name is not matched: the user is typing a
+ * username into a username box, not addressing an entry by its label.
+ */
+function filterLoginsByQuery(logins: MatchSummary[], query: string): MatchSummary[] {
+	const q = query.trim().toLowerCase();
+	if (!q) return logins;
+	return logins.filter((m) => {
+		const secondary = m.secondary.toLowerCase();
+		return secondary.startsWith(q) || q.startsWith(secondary);
+	});
+}
+
+// The query to filter by: the last value the user actually typed into the username field via
+// a real "input" event, not whatever value the field merely holds. A page that pre-fills a
+// remembered email (or an autofocus default) must not silently hide every saved login before
+// the user has typed anything themselves; only a genuine keystroke should narrow the list.
+const typedUsernameQuery = new WeakMap<HTMLInputElement, string>();
+
+/** Logins to offer on `field`: all matches, or filtered by what the user has actually typed. */
+function visibleLoginsForField(field: HTMLInputElement, logins: MatchSummary[]): MatchSummary[] {
+	if (field !== getPageFields().login.username) return logins;
+	const query = typedUsernameQuery.get(field);
+	if (!query) return logins;
+	return filterLoginsByQuery(logins, query);
+}
+
 /** Shows the login picker for `field`: existing matches, or ONLY the strong-password row on a signup/rotation form. */
 function showLoginPicker(field: HTMLInputElement, logins: MatchSummary[]): void {
 	const suggest = maybeSuggest(field, logins.length > 0);
@@ -463,8 +492,15 @@ function showLoginPicker(field: HTMLInputElement, logins: MatchSummary[]): void 
 	}
 	// Same policy, one field over: the signup form's email box gets nothing either.
 	if (isCreationField(field)) return;
-	if (logins.length === 0) return;
-	showMatchesFor(logins, field);
+	const visible = visibleLoginsForField(field, logins);
+	if (visible.length === 0) {
+		// Full dismissal, not picker.removeDropdown(): that only tears down the shadow-DOM
+		// (COEP-fallback) renderer and is a no-op against the primary iframe renderer, and it
+		// leaves any relayed (cross-origin iframe) picker painted too.
+		removePicker();
+		return;
+	}
+	showMatchesFor(visible, field);
 }
 
 /**
@@ -667,9 +703,14 @@ function showFor(field: HTMLInputElement): void {
 		queryAutofill();
 		return;
 	}
-	if (cachedResult.logins.length > 1 || !field.value) {
-		showLoginPicker(field, cachedResult.logins);
+	// A single saved login has nothing to disambiguate: get out of the way while the user
+	// types their own value. This is a property of the site (how many logins it has), not of
+	// how the typed query narrows them, so it uses the unfiltered count.
+	if (cachedResult.logins.length === 1 && field.value) {
+		removePicker();
+		return;
 	}
+	showLoginPicker(field, cachedResult.logins);
 }
 
 // Nodes that can hold, or turn into, a fillable field. A batch that moves
@@ -990,6 +1031,11 @@ function bootstrap(): void {
 			const target = composedTarget(e);
 			if (!couldBeCandidate(target) || !isCandidate(getPageFields(), target)) return;
 			silenceAutoOpen = false;
+			// Record what the user actually typed, as opposed to whatever the field merely
+			// holds (a pre-filled remembered value, an autofocus default): only a real
+			// keystroke here should narrow the login picker's filter.
+			if (target.value) typedUsernameQuery.set(target, target.value);
+			else typedUsernameQuery.delete(target);
 			if (!cachedResult) {
 				queryAutofill();
 				return;
@@ -1005,7 +1051,7 @@ function bootstrap(): void {
 							? (cachedResult.otps ?? []).length
 							: cachedResult.logins.length;
 				if (count <= 1) {
-					picker.removeDropdown();
+					removePicker();
 					return;
 				}
 			}


### PR DESCRIPTION
## Summary
- The autofill dropdown always showed every saved login for a field, even after the user started typing their own username/email.
- Filters the offered logins to those whose saved username matches what the user actually typed (either direction: `alice` matches a typed `alice@example.com` and vice versa), and hides the dropdown once typing narrows the list to zero matches. Narrowing to exactly one match keeps that match on screen instead of hiding it.
- Filtering only reacts to a real `input` event, not to whatever value the field already holds. A page that pre-fills a remembered email, or an autofocus default, is not treated as a search.
- Dismissal now goes through `removePicker()` (`picker.remove()` + `dropRelayed()`) everywhere in this path, instead of `picker.removeDropdown()`, so it actually hides on the primary iframe renderer and any relayed (cross-origin iframe) picker, not just the shadow-DOM fallback.
- Behavior change beyond the above: `showLoginPicker` now calls `removePicker()` whenever there is nothing to show, including the pre-existing case where `logins` was empty to begin with (not just when filtering narrows it to empty). Previously that case was a silent no-op; now a re-query that comes back empty actively clears any stale picker still on screen.
- One-sentence addition to `docs/autofill.md` documenting the type-ahead filter.

## Test plan
- [x] `pnpm exec vitest run src/content/content.dom.test.ts` in `packages/platform-extension` (44 passed)
- [x] `pnpm run typecheck`
- [x] `pnpm exec biome check` on the changed files