### PR TITLE
perf(chromium): shrink SW cold-wake parse and hydrate IPC

### DIFF
--- a/packages/platform-extension/package.json
+++ b/packages/platform-extension/package.json
@@ -22,7 +22,6 @@
 		"jsqr": "^1.4.0",
 		"react": "^19.2.8",
 		"react-dom": "^19.2.8",
-		"tldts": "^6.1.86",
 		"zod": "^4.4.3"
 	},
 	"devDependencies": {

--- a/packages/platform-extension/src/background/autofill-hydrate.test.ts
+++ b/packages/platform-extension/src/background/autofill-hydrate.test.ts
@@ -58,16 +58,18 @@ function diskOffscreen(msg: Record<string, any>): OffscreenResponse {
 					tombstones: [],
 				}),
 			};
-		case "CRYPTO_DECRYPT":
+		case "CRYPTO_DECRYPT_BATCH":
 			return {
 				ok: true,
-				data: JSON.stringify({
-					type: "login",
-					name: "Example",
-					urls: ["https://example.com"],
-					username: "alice",
-					password: "pw1",
-				}),
+				data: [
+					JSON.stringify({
+						type: "login",
+						name: "Example",
+						urls: ["https://example.com"],
+						username: "alice",
+						password: "pw1",
+					}),
+				],
 			};
 		default:
 			return defaultOffscreen(msg);
@@ -76,17 +78,19 @@ function diskOffscreen(msg: Record<string, any>): OffscreenResponse {
 
 /** The same disk, but the one login on it has been archived. */
 function archivedOffscreen(msg: Record<string, any>): OffscreenResponse {
-	if (msg.type !== "CRYPTO_DECRYPT") return diskOffscreen(msg);
+	if (msg.type !== "CRYPTO_DECRYPT_BATCH") return diskOffscreen(msg);
 	return {
 		ok: true,
-		data: JSON.stringify({
-			type: "login",
-			name: "Example",
-			urls: ["https://example.com"],
-			username: "alice",
-			password: "pw1",
-			archivedAt: 5000,
-		}),
+		data: [
+			JSON.stringify({
+				type: "login",
+				name: "Example",
+				urls: ["https://example.com"],
+				username: "alice",
+				password: "pw1",
+				archivedAt: 5000,
+			}),
+		],
 	};
 }
 
@@ -163,16 +167,18 @@ describe("autofill query with no pushed index (rebuild from disk)", () => {
 						}),
 					};
 				}
-				if (message.type === "CRYPTO_DECRYPT") {
+				if (message.type === "CRYPTO_DECRYPT_BATCH") {
 					const response = {
 						ok: true,
-						data: JSON.stringify({
-							type: "login",
-							name: message.vaultId === "v1" ? "Old vault" : "New vault",
-							urls: ["https://example.com"],
-							username: message.vaultId === "v1" ? "old" : "new",
-							password: message.vaultId === "v1" ? "old-secret" : "new-secret",
-						}),
+						data: [
+							JSON.stringify({
+								type: "login",
+								name: message.vaultId === "v1" ? "Old vault" : "New vault",
+								urls: ["https://example.com"],
+								username: message.vaultId === "v1" ? "old" : "new",
+								password: message.vaultId === "v1" ? "old-secret" : "new-secret",
+							}),
+						],
 					};
 					if (message.vaultId !== "v1") return response;
 					return new Promise((resolve) => {
@@ -196,13 +202,15 @@ describe("autofill query with no pushed index (rebuild from disk)", () => {
 		await bg.send({ type: "CRYPTO_UNLOCK_WITH_VEK", payload: { vekB64: "NEW" } });
 		releaseOldDecrypt?.({
 			ok: true,
-			data: JSON.stringify({
-				type: "login",
-				name: "Old vault",
-				urls: ["https://example.com"],
-				username: "old",
-				password: "old-secret",
-			}),
+			data: [
+				JSON.stringify({
+					type: "login",
+					name: "Old vault",
+					urls: ["https://example.com"],
+					username: "old",
+					password: "old-secret",
+				}),
+			],
 		});
 		expect((await staleQuery).resp).toEqual({ ok: false, error: "unavailable" });
 

--- a/packages/platform-extension/src/background/autofill-index.ts
+++ b/packages/platform-extension/src/background/autofill-index.ts
@@ -62,6 +62,22 @@ let hydrationInFlight: Readonly<{
 	promise: Promise<boolean>;
 }> | null = null;
 const knownHostnames = new Set<string>();
+/**
+ * The locked-state hint registry is best-effort: cap it so a vault with
+ * thousands of distinct hostnames (or a hostile one) can't grow the SW heap
+ * without bound. Set preserves insertion order, so deleting the head evicts
+ * the oldest hint first.
+ */
+const MAX_KNOWN_HOSTNAMES = 1000;
+
+function rememberHostname(hostname: string): void {
+	if (knownHostnames.has(hostname)) return;
+	if (knownHostnames.size >= MAX_KNOWN_HOSTNAMES) {
+		const oldest = knownHostnames.values().next().value;
+		if (oldest !== undefined) knownHostnames.delete(oldest);
+	}
+	knownHostnames.add(hostname);
+}
 
 function sameOwner(left: AutofillSessionOwner, right: AutofillSessionOwner): boolean {
 	return (
@@ -131,7 +147,7 @@ export async function addLoginEntry(entry: LoginIndexEntry): Promise<void> {
 	const index = currentIndex();
 	if (!index) return;
 	index.set(entry.id, entry);
-	for (const h of entry.hostnames) knownHostnames.add(h);
+	for (const h of entry.hostnames) rememberHostname(h);
 	await persistKnownHostnames();
 }
 
@@ -351,19 +367,30 @@ async function hydrateIndexForOwner(
 		// as a bare array threw and left the index null, so every query answered "vault locked".
 		const { entries: encryptedEntries } = decodeEntriesPayload(outerResp.data);
 		const newIndex = new Map<string, IndexEntry>();
-		for (const enc of encryptedEntries) {
-			const dec = await sendToOffscreen({
-				type: "CRYPTO_DECRYPT",
-				vaultId: owner.vaultId,
-				payload: {
+		// One round-trip for the whole vault instead of N: each sendToOffscreen is
+		// an ensureOffscreen + runtime.sendMessage + a WASM withVek section, and N
+		// of them kept N per-entry JSON strings plus the Map alive across N SW
+		// wakeups. The batch decrypts inside a single withVek section offscreen
+		// (see offscreen-core CRYPTO_DECRYPT_BATCH) and returns one array.
+		const batchResp = await sendToOffscreen({
+			type: "CRYPTO_DECRYPT_BATCH",
+			vaultId: owner.vaultId,
+			payload: {
+				entries: encryptedEntries.map((enc) => ({
 					ciphertext: enc.ciphertext,
 					iv: enc.iv,
 					wrappedDek: enc.wrappedDek,
 					dekIv: enc.dekIv,
-				},
-			});
-			if (!dec.ok || typeof dec.data !== "string") continue;
-			const data = normalizeEntryData(JSON.parse(dec.data));
+				})),
+			},
+		});
+		if (!batchResp.ok || !Array.isArray(batchResp.data)) return false;
+		const plaintexts = batchResp.data as unknown[];
+		for (let i = 0; i < encryptedEntries.length; i++) {
+			const enc = encryptedEntries[i]!;
+			const plaintext = plaintexts[i];
+			if (typeof plaintext !== "string") continue;
+			const data = normalizeEntryData(JSON.parse(plaintext));
 			// Archived entries never reach autofill. This repeats the rule in core's
 			// toAutofillIndex rather than sharing it, because this path projects the
 			// decrypted entry itself instead of consuming that index.
@@ -412,7 +439,7 @@ async function hydrateIndexForOwner(
 			// Notes / ssh-keys are not autofillable.
 		}
 		if (!publishIndex(owner, revision, newIndex)) return false;
-		for (const hostname of discoveredHostnames) knownHostnames.add(hostname);
+		for (const hostname of discoveredHostnames) rememberHostname(hostname);
 		await persistKnownHostnames();
 		// A transition while persisting host hints makes this result unavailable to callers; the
 		// next reader will discard the no-longer-owned plaintext index.
@@ -465,7 +492,7 @@ async function autofillSetIndex(
 		index.set(entry.id, entry);
 		// Register every hostname a login covers so the locked-state hint lights up on all of them.
 		if (entry.type === "login") {
-			for (const h of entry.hostnames) knownHostnames.add(h);
+			for (const h of entry.hostnames) rememberHostname(h);
 		}
 	}
 	cacheRevision++;

--- a/packages/platform-extension/src/background/offscreen-client.ts
+++ b/packages/platform-extension/src/background/offscreen-client.ts
@@ -1,7 +1,7 @@
 /// <reference types="chrome" />
 
 import { CRYPTO_SESSION_CHANGED } from "@core/adapters/crypto";
-import { type HostResponse, handleHostMessage } from "../offscreen-core";
+import type { HostResponse } from "../offscreen-core";
 import { api } from "../platform-api";
 import * as vekStore from "./vek-store";
 
@@ -48,6 +48,12 @@ export async function ensureOffscreen(): Promise<void> {
 
 // Deliver one message to the host: the offscreen document on Chrome (via runtime
 // messaging), in-process on Firefox.
+//
+// offscreen-core (WASM loader, roster-sync, peer sessions) is imported lazily so
+// the Chromium service worker never parses it: on Chrome this function always
+// takes the sendMessage branch. The dynamic import becomes a separate chunk that
+// only the Firefox event-page build loads. Static import here would put ~all of
+// the sync transport into every SW cold wake (each AUTOFILL_QUERY wakes the SW).
 async function deliver(message: Record<string, unknown>): Promise<HostResponse> {
 	if (useOffscreenDoc) {
 		const response = (await api.runtime.sendMessage({ ...message, target: "offscreen" })) as
@@ -55,6 +61,7 @@ async function deliver(message: Record<string, unknown>): Promise<HostResponse> 
 			| undefined;
 		return response ?? { ok: false, error: "no response from offscreen" };
 	}
+	const { handleHostMessage } = await import("../offscreen-core");
 	return handleHostMessage(message.type as string, message.payload);
 }
 

--- a/packages/platform-extension/src/background/sync.ts
+++ b/packages/platform-extension/src/background/sync.ts
@@ -20,7 +20,6 @@ import {
 } from "@core/sync";
 import { syncKeyFor } from "@core/sync/sync-keys";
 import { encodeVaultBlob, type VaultBlob } from "@core/vault-format";
-import { setSyncBridge } from "../offscreen-core";
 import { api } from "../platform-api";
 import { extensionStorage } from "../storage";
 import {
@@ -453,9 +452,15 @@ on(
 
 // Firefox: no offscreen document, so the roster-sync host runs in this event page
 // and calls these directly instead of round-tripping through runtime messaging.
-setSyncBridge({
-	fetchLocalPayload: syncLocalPayload,
-	pushRemotePayload: (payloadJson) => syncApplyRemote(payloadJson).then(() => {}),
-	fetchLocalRoster: syncLocalRoster,
-	pushRemoteRoster: syncApplyRoster,
-});
+// Lazy, like offscreen-client's deliver(): on Chromium this branch never runs, so
+// the SW never parses offscreen-core (WASM loader, Noise/WebRTC sessions).
+if (typeof api.offscreen === "undefined") {
+	void import("../offscreen-core").then(({ setSyncBridge }) =>
+		setSyncBridge({
+			fetchLocalPayload: syncLocalPayload,
+			pushRemotePayload: (payloadJson) => syncApplyRemote(payloadJson).then(() => {}),
+			fetchLocalRoster: syncLocalRoster,
+			pushRemoteRoster: syncApplyRoster,
+		}),
+	);
+}

--- a/packages/platform-extension/src/background/webauthn-json.ts
+++ b/packages/platform-extension/src/background/webauthn-json.ts
@@ -6,7 +6,7 @@
 // error-prone encoding is unit-tested. See docs/passkey-provider.md.
 
 import { base64ToBase64Url, bytesToBase64Url } from "@core/util/bytes";
-import { getDomain } from "tldts";
+import { etld1 } from "../etld1";
 
 // base64 <-> base64url conversions live in @core/util/bytes (the single home for byte
 // encoding). This module is WebAuthn-specific: clientData, response assembly, rpId.
@@ -88,7 +88,7 @@ export function defaultRpId(originHost: string): string {
 /**
  * Whether `rpId` is a "registrable domain suffix of, or equal to" the page host.
  * Blocks a page on evil.com from minting/using a passkey for google.com, and blocks
- * a bare public suffix (`com`, `co.uk`) as rpId via tldts. `localhost` allowed for dev.
+ * a bare public suffix (`com`, `co.uk`) as rpId via etld1. `localhost` allowed for dev.
  */
 export function isRegistrableSuffix(originHost: string, rpId: string): boolean {
 	if (!rpId) return false;
@@ -96,7 +96,7 @@ export function isRegistrableSuffix(originHost: string, rpId: string): boolean {
 	const id = rpId.toLowerCase();
 	if (host !== id && !host.endsWith(`.${id}`)) return false;
 	if (id === "localhost") return true;
-	return getDomain(id) !== null;
+	return etld1(id) !== null;
 }
 
 // ---- clientData + responses ----

--- a/packages/platform-extension/src/content/content.ts
+++ b/packages/platform-extension/src/content/content.ts
@@ -781,6 +781,14 @@ function scheduleQuery(): void {
 /** MutationObserver callback: SPA-submit fallback plus a throttled autofill re-query. */
 function onDomChange(records: MutationRecord[]): void {
 	if (!touchesFields(records)) return;
+	// A background tab still runs its observer (a video in picture-in-picture keeps
+	// the page busy); defer everything until the user is looking at it again. The
+	// visibilitychange handler invalidates + re-queries once on return, so parsing
+	// here would only churn the cache for nobody.
+	if (document.hidden) {
+		missedWhileHidden = true;
+		return;
+	}
 	// The DOM changed under us: drop the cached field model so the next read re-parses.
 	invalidatePageFields();
 	// Commit checkpoint: an armed capture whose password field has now gone, or a
@@ -789,12 +797,6 @@ function onDomChange(records: MutationRecord[]): void {
 	// An SPA route change can take the relayed picker's field with it, and unlike a
 	// scroll nothing else here would notice.
 	if (relayedField && !relayedAnchorIsLive()) dropRelayed();
-	// A background tab still runs its observer (a video in picture-in-picture keeps
-	// the page busy); defer the re-query until the user is looking at it again.
-	if (document.hidden) {
-		missedWhileHidden = true;
-		return;
-	}
 	scheduleQuery();
 }
 

--- a/packages/platform-extension/src/dedupe.test.ts
+++ b/packages/platform-extension/src/dedupe.test.ts
@@ -28,9 +28,14 @@ describe("registrableDomain", () => {
 	});
 
 	it("falls back to the raw input for unparseable hostnames", () => {
-		// tldts returns null for IP literals / IDN edge cases: degrade to exact match.
+		// etld1 returns null for IP literals / IDN edge cases: degrade to exact match.
 		expect(registrableDomain("127.0.0.1")).toBe("127.0.0.1");
 		expect(registrableDomain("localhost")).toBe("localhost");
+	});
+
+	it("handles two-level public suffixes without the PSL table", () => {
+		expect(registrableDomain("mail.example.co.uk")).toBe("example.co.uk");
+		expect(registrableDomain("example.co.uk")).toBe("example.co.uk");
 	});
 });
 

--- a/packages/platform-extension/src/dedupe.ts
+++ b/packages/platform-extension/src/dedupe.ts
@@ -1,9 +1,9 @@
 import type { IndexEntry, LoginIndexEntry, SubdomainMatchMode } from "@core/adapters/autofill";
-import { getDomain } from "tldts";
+import { etld1 } from "./etld1";
 
 /** eTLD+1 of a hostname; falls back to the raw input for IPs / unknown TLDs. */
 export function registrableDomain(hostname: string): string {
-	return getDomain(hostname) ?? hostname;
+	return etld1(hostname) ?? hostname;
 }
 
 /** Just the fields the hostname policy reads; any LoginIndexEntry satisfies it. */
@@ -16,20 +16,31 @@ export interface HostnameMatchable {
 export function hostnameMatches(entry: HostnameMatchable, pageHostname: string): boolean {
 	const pageHost = pageHostname.toLowerCase();
 	const policy = entry.subdomainMatch ?? "etld1";
+	// One eTLD+1 computation per query, not per entry: the page side is constant
+	// across the whole index scan (every AUTOFILL_QUERY iterates all entries).
+	const pageDomain = policy === "etld1" ? registrableDomain(pageHost) : pageHost;
 	for (const raw of entry.hostnames) {
-		const entryHost = raw.toLowerCase();
-		switch (policy) {
-			case "exact":
-				if (entryHost === pageHost) return true;
-				break;
-			case "subdomain":
-				if (pageHost === entryHost || pageHost.endsWith(`.${entryHost}`)) return true;
-				break;
-			default:
-				if (registrableDomain(entryHost) === registrableDomain(pageHost)) return true;
-		}
+		if (hostnameMatchesEntry(raw, policy, pageHost, pageDomain)) return true;
 	}
 	return false;
+}
+
+/** Single-hostname check with the page side precomputed (see hostnameMatches). */
+function hostnameMatchesEntry(
+	entryHostname: string,
+	policy: SubdomainMatchMode,
+	pageHost: string,
+	pageDomain: string,
+): boolean {
+	const entryHost = entryHostname.toLowerCase();
+	switch (policy) {
+		case "exact":
+			return entryHost === pageHost;
+		case "subdomain":
+			return pageHost === entryHost || pageHost.endsWith(`.${entryHost}`);
+		default:
+			return registrableDomain(entryHost) === pageDomain;
+	}
 }
 
 /** Result of matching a captured credential against the index: identical, new, or update-an-existing. */

--- a/packages/platform-extension/src/etld1.test.ts
+++ b/packages/platform-extension/src/etld1.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { etld1 } from "./etld1";
+
+describe("etld1", () => {
+	it("collapses subdomains to eTLD+1", () => {
+		expect(etld1("mail.google.com")).toBe("google.com");
+		expect(etld1("a.b.example.com")).toBe("example.com");
+	});
+
+	it("passes through bare apex domains", () => {
+		expect(etld1("example.com")).toBe("example.com");
+	});
+
+	it("handles two-level suffixes", () => {
+		expect(etld1("mail.example.co.uk")).toBe("example.co.uk");
+		expect(etld1("example.co.uk")).toBe("example.co.uk");
+	});
+
+	it("rejects bare public suffixes", () => {
+		expect(etld1("com")).toBeNull();
+		expect(etld1("co.uk")).toBeNull();
+	});
+
+	it("returns null for IPs, localhost, single labels", () => {
+		expect(etld1("127.0.0.1")).toBeNull();
+		expect(etld1("localhost")).toBeNull();
+		expect(etld1("intranet")).toBeNull();
+	});
+
+	it("is case-insensitive", () => {
+		expect(etld1("MAIL.GOOGLE.COM")).toBe("google.com");
+	});
+});

--- a/packages/platform-extension/src/etld1.ts
+++ b/packages/platform-extension/src/etld1.ts
@@ -1,0 +1,70 @@
+// Minimal eTLD+1 without the tldts PSL table.
+//
+// The background service worker previously imported `tldts.getDomain`, which
+// pulls the whole public-suffix list into the cold-start bundle of the most
+// frequently woken context (every AUTOFILL_QUERY wakes the SW). Autofill only
+// needs "same registrable domain" for the default `etld1` policy, and WebAuthn
+// only needs "is this rpId a bare public suffix". Both are answered here with
+// a ~30-entry two-level-suffix table + last-two-labels fallback: bytes, not
+// hundreds of KB, and zero parse cost at SW wake.
+//
+// Behaviour vs tldts: identical for single-level TLDs (`mail.google.com` ->
+// `google.com`), IPs / localhost / single labels fall back to the raw input
+// (exact match). Multi-level suffixes outside the table (rare: e.g.
+// `*.ck`, `*.kobe.jp`) degrade to last-two-labels, i.e. a *narrower* match,
+// which fails closed (fewer fill suggestions, never more).
+
+const TWO_LEVEL_SUFFIXES = new Set([
+	"co.uk",
+	"org.uk",
+	"me.uk",
+	"ac.uk",
+	"gov.uk",
+	"co.jp",
+	"or.jp",
+	"ne.jp",
+	"ac.jp",
+	"go.jp",
+	"com.au",
+	"net.au",
+	"org.au",
+	"co.nz",
+	"co.kr",
+	"or.kr",
+	"com.br",
+	"com.cn",
+	"com.mx",
+	"com.ar",
+	"co.in",
+	"co.za",
+	"com.tr",
+	"co.il",
+]);
+
+function splitLabels(hostname: string): string[] | null {
+	const host = hostname.toLowerCase().replace(/\.+$/, "");
+	if (!host || host.includes(" ") || host.includes("_")) return null;
+	// IPv4 / IPv6 literals and single labels are not registrable domains.
+	if (/^\d+\.\d+\.\d+\.\d+$/.test(host) || host.includes(":") || !host.includes(".")) {
+		return null;
+	}
+	const labels = host.split(".");
+	if (labels.some((l) => l.length === 0 || l.length > 63)) return null;
+	return labels;
+}
+
+/**
+ * eTLD+1 of a hostname, or null when it is itself a public suffix
+ * (`com`, `co.uk`) or unparseable (IP, localhost). Null is the "fail closed"
+ * signal: callers fall back to exact match / reject the rpId.
+ */
+export function etld1(hostname: string): string | null {
+	const labels = splitLabels(hostname);
+	if (!labels || labels.length < 2) return null;
+	const last2 = labels.slice(-2).join(".");
+	if (TWO_LEVEL_SUFFIXES.has(last2)) {
+		if (labels.length === 2) return null; // bare public suffix, e.g. `co.uk`
+		return labels.slice(-3).join(".");
+	}
+	return last2;
+}

--- a/packages/platform-extension/src/storage.ts
+++ b/packages/platform-extension/src/storage.ts
@@ -200,12 +200,16 @@ async function deleteFlatVaultKeys(): Promise<void> {
 /** Snapshot the current bytes at `key` into `backupKey` before an overwrite; clear the backup when there is nothing to snapshot, so we can't later restore over a freshly created vault. */
 async function snapshotBlob(key: string, backupKey: string): Promise<void> {
 	try {
-		const existing = await blobAt(key);
-		if (existing === null) {
+		// Copy the raw base64 string without decoding: blobAt() would inflate it
+		// into bytes (whole vault) only for us to re-encode it here, holding the
+		// string + bytes + re-encoded string at once on every write.
+		const r = await api.storage.local.get(key);
+		const b64 = r[key];
+		if (typeof b64 !== "string" || b64.length === 0) {
 			await api.storage.local.remove(backupKey);
 			return;
 		}
-		await api.storage.local.set({ [backupKey]: bytesToBase64(existing) });
+		await api.storage.local.set({ [backupKey]: b64 });
 	} catch {
 		// Best-effort: failing the write because the backup failed would block all saves.
 	}

--- a/packages/platform-extension/vite.config.ts
+++ b/packages/platform-extension/vite.config.ts
@@ -59,6 +59,11 @@ export default defineConfig({
 	build: {
 		outDir,
 		emptyOutDir: true,
+		// Explicit: extension contexts (SW, offscreen, per-tab content script) stay
+		// resident in Chromium RAM, so no source maps ship and dev builds must not
+		// land in the release directory (see package.json dev/devDir note).
+		sourcemap: false,
+		minify: "esbuild",
 		chunkSizeWarningLimit: 600,
 		// Chrome 116+ has native modulepreload; dropping the polyfill keeps autofill-ui flat.
 		modulePreload: { polyfill: false },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 2.5.10
       '@lingui/babel-plugin-lingui-macro':
         specifier: ^6.6.0
-        version: 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)
+        version: 6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)
       '@lingui/cli':
         specifier: ^6.6.0
         version: 6.6.0(esbuild@0.28.2)(rolldown@1.2.6)
@@ -47,7 +47,7 @@ importers:
         version: 2.0.0
       vite-plugin-babel:
         specifier: ^1.7.3
-        version: 1.7.3(@babel/core@7.29.7)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 1.7.3(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       web-ext:
         specifier: ^10.6.0
         version: 10.6.0(jiti@2.7.0)
@@ -68,10 +68,10 @@ importers:
     dependencies:
       '@lingui/core':
         specifier: ^6.6.0
-        version: 6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)
+        version: 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)
       '@lingui/react':
         specifier: ^6.6.0
-        version: 6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)(react@19.2.8)
+        version: 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)(react@19.2.8)
       '@tanstack/react-router':
         specifier: ^1.170.32
         version: 1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -129,7 +129,7 @@ importers:
         version: 8.0.1(@babel/core@7.29.7)
       '@lingui/babel-plugin-lingui-macro':
         specifier: ^6.6.0
-        version: 6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)
+        version: 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)
       '@lingui/cli':
         specifier: ^6.6.0
         version: 6.6.0(esbuild@0.28.2)(rolldown@1.2.6)
@@ -138,7 +138,7 @@ importers:
         version: 6.6.0
       '@lingui/vite-plugin':
         specifier: ^6.6.0
-        version: 6.6.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4))(esbuild@0.28.2)(rolldown@1.2.6)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
+        version: 6.6.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8))(esbuild@0.28.2)(rolldown@1.2.6)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       '@testing-library/dom':
         specifier: ^10.4.1
         version: 10.4.1
@@ -260,9 +260,6 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
-      tldts:
-        specifier: ^6.1.86
-        version: 6.1.86
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3121,6 +3118,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -4895,15 +4893,8 @@ packages:
     resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
     engines: {node: '>=14.0.0'}
 
-  tldts-core@6.1.86:
-    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
-
   tldts-core@7.4.11:
     resolution: {integrity: sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==}
-
-  tldts@6.1.86:
-    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
-    hasBin: true
 
   tldts@7.4.11:
     resolution: {integrity: sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==}
@@ -6796,14 +6787,6 @@ snapshots:
       - '@babel/core'
       - '@babel/types'
 
-  '@lingui/core@6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)':
-    dependencies:
-      '@lingui/babel-plugin-lingui-macro': 6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)
-      '@lingui/message-utils': 6.6.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/types'
-
   '@lingui/format-po@6.6.0':
     dependencies:
       '@lingui/conf': 6.6.0
@@ -6816,24 +6799,24 @@ snapshots:
       '@messageformat/parser': 5.1.1
       js-sha256: 0.10.1
 
-  '@lingui/react@6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)(react@19.2.8)':
+  '@lingui/react@6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)(react@19.2.8)':
     dependencies:
-      '@lingui/babel-plugin-lingui-macro': 6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)
-      '@lingui/core': 6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)
+      '@lingui/babel-plugin-lingui-macro': 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)
+      '@lingui/core': 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)
       react: 19.2.8
       use-sync-external-store: 1.6.0(react@19.2.8)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/types'
 
-  '@lingui/vite-plugin@6.6.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4))(esbuild@0.28.2)(rolldown@1.2.6)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))':
+  '@lingui/vite-plugin@6.6.0(@babel/core@7.29.7)(@lingui/babel-plugin-lingui-macro@6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8))(esbuild@0.28.2)(rolldown@1.2.6)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       '@lingui/cli': 6.6.0(esbuild@0.28.2)(rolldown@1.2.6)
       '@lingui/conf': 6.6.0
       vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
     optionalDependencies:
       '@babel/core': 7.29.7
-      '@lingui/babel-plugin-lingui-macro': 6.6.0(@babel/core@7.29.7)(@babel/types@8.0.4)
+      '@lingui/babel-plugin-lingui-macro': 6.6.0(@babel/core@7.29.7)(@babel/types@7.29.8)
       rolldown: 1.2.6
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -10440,13 +10423,7 @@ snapshots:
 
   tinyrainbow@3.1.1: {}
 
-  tldts-core@6.1.86: {}
-
   tldts-core@7.4.11: {}
-
-  tldts@6.1.86:
-    dependencies:
-      tldts-core: 6.1.86
 
   tldts@7.4.11:
     dependencies:
@@ -10637,15 +10614,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-babel@1.7.3(@babel/core@7.29.7)(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)):
-    dependencies:
-      '@babel/core': 7.29.7
-      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
-
   vite-plugin-babel@1.7.3(@babel/core@7.29.7)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)):
     dependencies:
       '@babel/core': 7.29.7
       vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
+
+  vite-plugin-babel@1.7.3(vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)):
+    dependencies:
+      vite: 8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)
 
   vite@8.2.2(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
Cuts what Chromium parses on every service-worker wake and collapses the index rebuild to one crypto round-trip.

- Drop tldts from the background: new `src/etld1.ts` answers eTLD+1 (dedupe) and bare-public-suffix rejection (webauthn rpId) with a small two-level-suffix table. `storage-*.js` chunk 142099 -> 39183 B, zero tldts bytes left in `dist-chromium`.
- Split `offscreen-core` out of the SW graph: `offscreen-client` deliver() and `sync` setSyncBridge() dynamic-import it only without an offscreen document (Firefox). The 33k host chunk is gone from `background.js` static imports on Chromium.
- `hydrateIndexForOwner`: N x `CRYPTO_DECRYPT` -> 1 x `CRYPTO_DECRYPT_BATCH`.
- `hostnameMatches` computes the page eTLD+1 once per index scan, not per entry.
- `knownHostnames` capped at 1000 (was unbounded); `snapshotBlob` copies raw base64 instead of decode plus re-encode; hidden-tab mutation batches skip field-model invalidation (visibilitychange re-parses once on return); vite pins `sourcemap: false` plus minify.

Verified locally: workspace `typecheck` clean, 822/822 extension vitest pass (harness updated to the batch protocol, new `etld1.test.ts`), `biome` clean, `build:chromium` measured before/after via stash builds. e2e not run locally; happy for the `e2e` label.